### PR TITLE
Custom cache directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Based on [yandex-music-open-api](https://github.com/acherkashin/yandex-music-ope
 ### Requirements
 
 To use this client, you should have a valid Yandex Music account and an access token.<br>
-The easiest way to get a token is to use this
-[browser extension](https://github.com/MarshalX/yandex-music-token/tree/main/browser-extension).
+The easiest way to get a token is to use a browser extension ([Chrome](https://chrome.google.com/webstore/detail/yandex-music-token/lcbjeookjibfhjjopieifgjnhlegmkib), [Firefox](https://addons.mozilla.org/en-US/firefox/addon/yandex-music-token/)).
 
 ### Implemented features
 
@@ -97,4 +96,4 @@ controls:
 
 You can list multiple keys for the same control, separated by commas.
 
-Increase the `buffer-size-ms` if you have glitches or statters.
+Increase the `buffer-size-ms` if you have glitches or stutters.

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -12,14 +12,21 @@ func getCacheDir() (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	configDir := filepath.Join(userDir, config.ConfigPath)
-	err = os.MkdirAll(configDir, 0755)
+	var cacheDir string
+	if config.Current.CacheDir == "default" {
+		cacheDir = filepath.Join(userDir, config.ConfigPath)
+	} else {
+		cacheDir, err = filepath.Abs(config.Current.CacheDir)
+	}
+	if err != nil {
+		return "", err
+	}
+	err = os.MkdirAll(cacheDir, 0755)
 	if err != nil {
 		return "", err
 	}
 
-	return configDir, nil
+	return cacheDir, nil
 }
 
 func Read(trackId string) (*os.File, int64, error) {

--- a/config/types.go
+++ b/config/types.go
@@ -82,6 +82,7 @@ type Config struct {
 	Volume         float64   `yaml:"volume"`
 	VolumeStep     float64   `yaml:"volume-step"`
 	CacheTracks    CacheType `yaml:"cache-tracks"`
+	CacheDir       string    `yaml:"cache-dir"`
 	Search         *Search   `yaml:"search"`
 	Controls       *Controls `yaml:"controls"`
 }
@@ -92,6 +93,7 @@ var defaultConfig = Config{
 	Volume:         0.5,
 	VolumeStep:     0.05,
 	CacheTracks:    CACHE_LIKED_ONLY,
+	CacheDir:       "default",
 	Search: &Search{
 		Artists:   true,
 		Albums:    false,

--- a/ui/model/mainPage/mainPage.go
+++ b/ui/model/mainPage/mainPage.go
@@ -2,6 +2,7 @@ package mainpage
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"time"
@@ -318,17 +319,16 @@ func (m *Model) initialLoad() error {
 	if len(config.Current.Token) == 0 {
 		return fmt.Errorf("wrong token")
 	}
+	m.client, err = api.NewClient(config.Current.Token)
+	if err != nil {
+		if _, ok := err.(*url.Error); ok {
+			return fmt.Errorf("unable to connect to the Yandex server")
+		} else {
+			return err
+		}
+	}
 
-	// m.client, err = api.NewClient(config.Current.Token)
-	// if err != nil {
-	// 	if _, ok := err.(*url.Error); ok {
-	// 		return fmt.Errorf("unable to connect to the Yandex server")
-	// 	} else {
-	// 		return err
-	// 	}
-	// }
-
-	m.client = &api.YaMusicClient{}
+	//m.client = &api.YaMusicClient{}
 
 	for i, station := range m.playlists.Items() {
 		switch station.Kind {


### PR DESCRIPTION
Added:
- the ability to use a custom directory for cached tracks
- a config parameter to select a custom directory for ~~downloaded~~ cached tracks

sixel images dont work in a sixel supported terminal, afraid of editing their code.
uncommented the thing that caused #14 