### PR TITLE
Fixed 403 error from Yandex server

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -45,7 +45,7 @@ var mTLSConfig = &tls.Config{
 		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 	},
 	MinVersion: tls.VersionTLS12,
-	MaxVersion: tls.VersionTLS12,
+	// MaxVersion: tls.VersionTLS12,
 }
 
 var httpClient = http.Client{Transport: &http.Transport{


### PR DESCRIPTION
This is the minimal change that removes the error. Probably Yandex could start detecting this app as a bot again in some time and further changes would be required.
