### PR TITLE
Player UX improvements: volume indicator with dynamic step acceleration, fix a family of bugs causing track cursor/selection desync and visual "jerking" in the tracklist, add page navigation keybindings.

### DIFF
--- a/config/types.go
+++ b/config/types.go
@@ -86,6 +86,8 @@ type Controls struct {
 	PlaylistsRename *Key `yaml:"playlists-rename"`
 	PlaylistsHide   *Key `yaml:"playlists-hide"`
 	// Track list control
+	PageUp                   *Key `yaml:"page-up"`
+	PageDown                 *Key `yaml:"page-down"`
 	TracksLike               *Key `yaml:"tracks-like"`
 	TracksAddToPlaylist      *Key `yaml:"tracks-add-to-playlist"`
 	TracksRemoveFromPlaylist *Key `yaml:"tracks-remove-from-playlist"`
@@ -154,6 +156,8 @@ var defaultConfig = Config{
 		PlaylistsDown:            NewKey("ctrl+down"),
 		PlaylistsRename:          NewKey("ctrl+r"),
 		PlaylistsHide:            NewKey("ctrl+b"),
+		PageUp:                   NewKey("pgup"),
+		PageDown:                 NewKey("pgdown"),
 		TracksLike:               NewKey("l"),
 		TracksAddToPlaylist:      NewKey("a"),
 		TracksRemoveFromPlaylist: NewKey("ctrl+a"),

--- a/ui/components/playlist/item.go
+++ b/ui/components/playlist/item.go
@@ -43,9 +43,24 @@ func (pl *Item) RemoveTrack(trackId string) int {
 			} else {
 				pl.Tracks = pl.Tracks[:i]
 			}
-			if pl.SelectedTrack == len(pl.Tracks) && len(pl.Tracks) > 0 {
-				pl.SelectedTrack--
+
+			if len(pl.Tracks) == 0 {
+				pl.SelectedTrack = 0
+				pl.CurrentTrack = 0
+			} else {
+				if pl.SelectedTrack > i {
+					pl.SelectedTrack--
+				} else if pl.SelectedTrack >= len(pl.Tracks) {
+					pl.SelectedTrack = len(pl.Tracks) - 1
+				}
+
+				if pl.CurrentTrack == i {
+					pl.CurrentTrack = len(pl.Tracks)
+				} else if pl.CurrentTrack > i {
+					pl.CurrentTrack--
+				}
 			}
+
 			return i
 		}
 	}

--- a/ui/components/playlist/item.go
+++ b/ui/components/playlist/item.go
@@ -29,6 +29,10 @@ func (i *Item) IsSame(other *Item) bool {
 
 func (pl *Item) AddTrack(track *api.Track) {
 	pl.Tracks = append([]api.Track{*track}, pl.Tracks...)
+	pl.SelectedTrack++
+	if pl.CurrentTrack < len(pl.Tracks)-1 {
+		pl.CurrentTrack++
+	}
 }
 
 func (pl *Item) AddTrackToEnd(track *api.Track) {

--- a/ui/components/tracker/helpKeys.go
+++ b/ui/components/tracker/helpKeys.go
@@ -72,7 +72,7 @@ func newHelpMap() *helpKeyMap {
 }
 
 func (k helpKeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.PlayPause, k.NextTrack, k.PrevTrack, k.LikeUnlike}
+	return []key.Binding{k.PlayPause, k.NextTrack, k.PrevTrack, k.LikeUnlike, k.VolUp, k.VolDown}
 }
 
 func (k helpKeyMap) FullHelp() [][]key.Binding {

--- a/ui/components/tracker/readWrapper.go
+++ b/ui/components/tracker/readWrapper.go
@@ -19,6 +19,7 @@ type readWrapper struct {
 	decoder        *mp3.Decoder
 	trackBuffer    *stream.BufferedStream
 	trackBuffered  bool
+	trackDone      bool
 	lastUpdateTime time.Time
 }
 
@@ -26,6 +27,7 @@ func (w *readWrapper) NewReader(reader *stream.BufferedStream) {
 	var err error
 
 	w.trackBuffered = false
+	w.trackDone = false
 	w.trackBuffer = reader
 	w.decoder, err = mp3.NewDecoder(w.trackBuffer)
 	if err != nil {
@@ -70,11 +72,12 @@ func (w *readWrapper) Read(dest []byte) (n int, err error) {
 		go w.program.Send(BUFFERING_COMPLETE)
 	}
 
-	if w.trackBuffer.IsDone() {
+	if w.trackBuffer.IsDone() && !w.trackDone {
+		w.trackDone = true
 		w.decoder.Seek(0, io.SeekStart)
 		w.trackBuffer.Close()
 		go w.program.Send(NEXT)
-	} else if time.Since(w.lastUpdateTime) > _PROGRESS_UPDATE_PERIOD {
+	} else if !w.trackDone && time.Since(w.lastUpdateTime) > _PROGRESS_UPDATE_PERIOD {
 		w.lastUpdateTime = time.Now()
 		fraction := ProgressControl(w.trackBuffer.Progress())
 		go w.program.Send(fraction)

--- a/ui/components/tracker/tracker.go
+++ b/ui/components/tracker/tracker.go
@@ -46,7 +46,8 @@ func (p ProgressControl) Value() float64 {
 }
 
 const (
-	_VOLUME_FADE_STEPS = 2
+	_VOLUME_FADE_STEPS      = 2
+	_VOLUME_INDICATOR_WIDTH = 5 // " NNN%"
 )
 
 var rewindAmount = time.Duration(config.Current.RewindDuration) * time.Second
@@ -130,8 +131,11 @@ func (m *Model) View() string {
 		playButton = style.ActiveButtonStyle.Padding(0, 1).Margin(0).Render(style.IconStop)
 	}
 
+	volumeText := fmt.Sprintf(" %3d%%", int(math.Round(m.volume*100)))
+	volumeIndicator := style.TrackVersionStyle.Render(volumeText)
+
 	tracker := style.TrackProgressStyle.Render(m.progress.View())
-	tracker = lipgloss.JoinHorizontal(lipgloss.Top, playButton, tracker)
+	tracker = lipgloss.JoinHorizontal(lipgloss.Top, playButton, tracker, volumeIndicator)
 
 	if m.showLyrics {
 		tracker = lipgloss.JoinVertical(lipgloss.Left, m.renderLyrics(), "", tracker)
@@ -299,7 +303,7 @@ func (m *Model) Update(message tea.Msg) (*Model, tea.Cmd) {
 
 func (m *Model) SetWidth(width int) {
 	m.width = width
-	m.progress.Width = width - 9
+	m.progress.Width = width - 9 - _VOLUME_INDICATOR_WIDTH
 	m.help.Width = width - 4
 }
 

--- a/ui/components/tracker/tracker.go
+++ b/ui/components/tracker/tracker.go
@@ -47,7 +47,9 @@ func (p ProgressControl) Value() float64 {
 
 const (
 	_VOLUME_FADE_STEPS      = 2
-	_VOLUME_INDICATOR_WIDTH = 5 // " NNN%"
+	_VOLUME_BAR_WIDTH       = 10
+	_VOLUME_INDICATOR_WIDTH = 20    // " Vol ██████████ 100%"
+	_VOLUME_SNAP_THRESHOLD  = 0.005 // snap to 0/1 when close enough
 )
 
 var rewindAmount = time.Duration(config.Current.RewindDuration) * time.Second
@@ -66,6 +68,7 @@ type Model struct {
 
 	volume         float64
 	volumeIncremet float64
+	lastVolumeKey  time.Time
 	playerContext  *oto.Context
 	player         *oto.Player
 	trackWrapper   *readWrapper
@@ -131,8 +134,11 @@ func (m *Model) View() string {
 		playButton = style.ActiveButtonStyle.Padding(0, 1).Margin(0).Render(style.IconStop)
 	}
 
-	volumeText := fmt.Sprintf(" %3d%%", int(math.Round(m.volume*100)))
-	volumeIndicator := style.TrackVersionStyle.Render(volumeText)
+	volumePercent := int(math.Round(m.volume * 100))
+	filledBars := int(math.Round(m.volume * _VOLUME_BAR_WIDTH))
+	filled := lipgloss.NewStyle().Foreground(style.AccentColor).Render(strings.Repeat("█", filledBars))
+	empty := lipgloss.NewStyle().Foreground(style.BackgroundColor).Render(strings.Repeat("░", _VOLUME_BAR_WIDTH-filledBars))
+	volumeIndicator := style.TrackVersionStyle.Render(" Vol ") + filled + empty + style.TrackVersionStyle.Render(fmt.Sprintf(" %3d%%", volumePercent))
 
 	tracker := style.TrackProgressStyle.Render(m.progress.View())
 	tracker = lipgloss.JoinHorizontal(lipgloss.Top, playButton, tracker, volumeIndicator)
@@ -259,11 +265,11 @@ func (m *Model) Update(message tea.Msg) (*Model, tea.Cmd) {
 			}
 
 		case controls.PlayerVolUp.Contains(keypress):
-			m.SetVolume(m.volume + config.Current.VolumeStep)
+			m.SetVolume(m.volume + m.dynamicVolumeStep())
 			cmds = append(cmds, model.Cmd(VOLUME))
 
 		case controls.PlayerVolDown.Contains(keypress):
-			m.SetVolume(m.volume - config.Current.VolumeStep)
+			m.SetVolume(m.volume - m.dynamicVolumeStep())
 			cmds = append(cmds, model.Cmd(VOLUME))
 
 		case controls.PlayerToggleLyrics.Contains(keypress):
@@ -331,9 +337,9 @@ func (m *Model) Position() time.Duration {
 }
 
 func (m *Model) SetVolume(v float64) {
-	if v < config.Current.VolumeStep/2 {
+	if v < _VOLUME_SNAP_THRESHOLD {
 		v = 0
-	} else if v > 1-config.Current.VolumeStep/2 {
+	} else if v > 1-_VOLUME_SNAP_THRESHOLD {
 		v = 1
 	}
 	m.volume = v
@@ -475,6 +481,22 @@ func (m *Model) ShowError(text string) {
 
 func (m *Model) HideError() {
 	m.showError = false
+}
+
+func (m *Model) dynamicVolumeStep() float64 {
+	now := time.Now()
+	delta := now.Sub(m.lastVolumeKey)
+	m.lastVolumeKey = now
+
+	step := config.Current.VolumeStep
+	switch {
+	case delta < 80*time.Millisecond:
+		return step
+	case delta < 200*time.Millisecond:
+		return step * 0.4
+	default:
+		return step * 0.2
+	}
 }
 
 func (m *Model) volumeFadeTick() {

--- a/ui/components/tracklist/helpKeys.go
+++ b/ui/components/tracklist/helpKeys.go
@@ -8,6 +8,8 @@ import (
 type helpKeyMap struct {
 	CursorUp           key.Binding
 	CursorDown         key.Binding
+	PageUp             key.Binding
+	PageDown           key.Binding
 	Play               key.Binding
 	LikeUnlike         key.Binding
 	AddToPlaylist      key.Binding
@@ -28,6 +30,8 @@ func newHelpMap() *helpKeyMap {
 	return &helpKeyMap{
 		CursorUp:           key.NewBinding(controls.CursorUp.Binding(), controls.CursorUp.Help("up")),
 		CursorDown:         key.NewBinding(controls.CursorDown.Binding(), controls.CursorDown.Help("down")),
+		PageUp:             key.NewBinding(controls.PageUp.Binding(), controls.PageUp.Help("page up")),
+		PageDown:           key.NewBinding(controls.PageDown.Binding(), controls.PageDown.Help("page down")),
 		Play:               key.NewBinding(controls.Apply.Binding(), controls.Apply.Help("play")),
 		LikeUnlike:         key.NewBinding(controls.TracksLike.Binding(), controls.TracksLike.Help("like/unlike")),
 		AddToPlaylist:      key.NewBinding(controls.TracksAddToPlaylist.Binding(), controls.TracksAddToPlaylist.Help("add to")),
@@ -48,8 +52,8 @@ func (k helpKeyMap) ShortHelp() []key.Binding {
 
 func (k helpKeyMap) FullHelp() [][]key.Binding {
 	bindings := [][]key.Binding{
-		{k.CursorUp, k.CursorDown, k.Play},
-		{k.LikeUnlike, k.AddToPlaylist, k.RemoveFromPlaylist},
+		{k.CursorUp, k.CursorDown, k.PageUp, k.PageDown},
+		{k.Play, k.LikeUnlike, k.AddToPlaylist, k.RemoveFromPlaylist},
 		{k.Search, k.Share},
 	}
 

--- a/ui/components/tracklist/tracklist.go
+++ b/ui/components/tracklist/tracklist.go
@@ -56,6 +56,8 @@ func New(p *tea.Program, likesMap *map[string]bool, cacheMap *map[string]bool) *
 		CursorUp:   key.NewBinding(controls.CursorUp.Binding(), controls.CursorUp.Help("up")),
 		CursorDown: key.NewBinding(controls.CursorDown.Binding(), controls.CursorDown.Help("down")),
 	}
+	m.list.Paginator.KeyMap.NextPage.SetEnabled(false)
+	m.list.Paginator.KeyMap.PrevPage.SetEnabled(false)
 	m.list.SetShowHelp(false)
 
 	m.help.Ellipsis = "…"

--- a/ui/components/tracklist/tracklist.go
+++ b/ui/components/tracklist/tracklist.go
@@ -55,6 +55,8 @@ func New(p *tea.Program, likesMap *map[string]bool, cacheMap *map[string]bool) *
 	m.list.KeyMap = list.KeyMap{
 		CursorUp:   key.NewBinding(controls.CursorUp.Binding(), controls.CursorUp.Help("up")),
 		CursorDown: key.NewBinding(controls.CursorDown.Binding(), controls.CursorDown.Help("down")),
+		NextPage:   key.NewBinding(controls.PageDown.Binding(), controls.PageDown.Help("pgdn")),
+		PrevPage:   key.NewBinding(controls.PageUp.Binding(), controls.PageUp.Help("pgup")),
 	}
 	m.list.Paginator.KeyMap.NextPage.SetEnabled(false)
 	m.list.Paginator.KeyMap.PrevPage.SetEnabled(false)
@@ -83,16 +85,9 @@ func (m *Model) View() string {
 	}
 
 	m.helpMap.Shafflable = m.Shufflable
-	listHeight := m.height
-
-	if m.help.ShowAll {
-		listHeight -= 7
-	} else {
-		listHeight -= 5
-	}
 
 	listView := m.list.View()
-	if lipgloss.Height(listView) <= listHeight {
+	if lipgloss.Height(listView) <= m.list.Height() {
 		lastLine := strings.LastIndex(listView[:len(listView)-1], "\n")
 		listView = listView[:lastLine] + "\n" + listView[lastLine:]
 	}
@@ -117,11 +112,7 @@ func (m *Model) Update(message tea.Msg) (*Model, tea.Cmd) {
 		switch {
 		case controls.ShowAllKeys.Contains(keypress):
 			m.help.ShowAll = !m.help.ShowAll
-			if m.help.ShowAll {
-				m.list.SetHeight(m.height - 7)
-			} else {
-				m.list.SetHeight(m.height - 5)
-			}
+			m.updateListHeight()
 		case controls.Apply.Contains(keypress):
 			cmds = append(cmds, model.Cmd(PLAY))
 		case controls.CursorUp.Contains(keypress):
@@ -212,11 +203,12 @@ func (m *Model) Width() int {
 
 func (m *Model) SetHeight(h int) {
 	m.height = h
-	if m.help.ShowAll {
-		m.list.SetHeight(m.height - 7)
-	} else {
-		m.list.SetHeight(m.height - 5)
-	}
+	m.updateListHeight()
+}
+
+func (m *Model) updateListHeight() {
+	helpHeight := lipgloss.Height(m.help.View(m.helpMap))
+	m.list.SetHeight(m.height - helpHeight - 2)
 }
 
 func (m *Model) Height() int {

--- a/ui/model/mainPage/cacheControl.go
+++ b/ui/model/mainPage/cacheControl.go
@@ -55,12 +55,21 @@ func (m *Model) removeCache(track *api.Track) tea.Cmd {
 	}
 
 	cachePlaylist, index := m.playlists.GetFirst(playlist.LOCAL)
-	trackIndex := cachePlaylist.RemoveTrack(track.Id)
-	if m.playlists.SelectedItem().Kind == playlist.LOCAL && trackIndex >= 0 {
-		m.tracklist.RemoveItem(trackIndex)
-		m.tracklist.Select(cachePlaylist.SelectedTrack)
-	}
+	cachePlaylist.RemoveTrack(track.Id)
 
 	delete(m.cachedTracksMap, track.Id)
-	return m.playlists.SetItem(index, cachePlaylist)
+	cmd := m.playlists.SetItem(index, cachePlaylist)
+
+	if m.playlists.SelectedItem().Kind == playlist.LOCAL {
+		m.displayPlaylist(cachePlaylist)
+	}
+
+	if m.currentPlaylistIndex >= 0 {
+		currentPlaylist := m.playlists.Items()[m.currentPlaylistIndex]
+		if cachePlaylist.IsSame(currentPlaylist) && m.tracker.IsPlaying() {
+			m.indicateCurrentTrackPlaying(currentPlaylist.CurrentTrack < len(currentPlaylist.Tracks))
+		}
+	}
+
+	return cmd
 }

--- a/ui/model/mainPage/likeControl.go
+++ b/ui/model/mainPage/likeControl.go
@@ -34,13 +34,21 @@ func (m *Model) likeTrack(track *api.Track) tea.Cmd {
 		delete(m.likedTracksMap, track.Id)
 
 		likedPlaylist, index := m.playlists.GetFirst(playlist.LIKES)
-		trackIndex := likedPlaylist.RemoveTrack(track.Id)
-		if m.playlists.SelectedItem().Kind == playlist.LIKES && trackIndex >= 0 {
-			m.tracklist.RemoveItem(trackIndex)
-			m.tracklist.Select(likedPlaylist.SelectedTrack)
+		likedPlaylist.RemoveTrack(track.Id)
+		cmd := m.playlists.SetItem(index, likedPlaylist)
+
+		if m.playlists.SelectedItem().Kind == playlist.LIKES {
+			m.displayPlaylist(likedPlaylist)
 		}
 
-		return m.playlists.SetItem(index, likedPlaylist)
+		if m.currentPlaylistIndex >= 0 {
+			currentPlaylist := m.playlists.Items()[m.currentPlaylistIndex]
+			if likedPlaylist.IsSame(currentPlaylist) && m.tracker.IsPlaying() {
+				m.indicateCurrentTrackPlaying(currentPlaylist.CurrentTrack < len(currentPlaylist.Tracks))
+			}
+		}
+
+		return cmd
 	} else {
 		if m.client.LikeTrack(track.Id) != nil {
 			return nil

--- a/ui/model/mainPage/playControl.go
+++ b/ui/model/mainPage/playControl.go
@@ -53,6 +53,8 @@ func (m *Model) prevTrack() {
 	m.playTrack(track)
 	if shouldFollow {
 		m.tracklist.Select(currentPlaylist.CurrentTrack)
+		currentPlaylist.SelectedTrack = currentPlaylist.CurrentTrack
+		m.playlists.SetItem(m.currentPlaylistIndex, currentPlaylist)
 	}
 }
 
@@ -133,6 +135,8 @@ func (m *Model) nextTrack() {
 	m.playTrack(track)
 	if shouldFollow {
 		m.tracklist.Select(currentPlaylist.CurrentTrack)
+		currentPlaylist.SelectedTrack = currentPlaylist.CurrentTrack
+		m.playlists.SetItem(m.currentPlaylistIndex, currentPlaylist)
 	}
 }
 

--- a/ui/model/mainPage/playControl.go
+++ b/ui/model/mainPage/playControl.go
@@ -33,20 +33,25 @@ func (m *Model) prevTrack() {
 		return
 	}
 
+	selectedPlaylist := m.playlists.SelectedItem()
+	shouldFollow := currentPlaylist.IsSame(selectedPlaylist) && m.tracklist.Index() == currentPlaylist.CurrentTrack
+
 	m.indicateCurrentTrackPlaying(false)
 
 	currentPlaylist.CurrentTrack--
+	for currentPlaylist.CurrentTrack > 0 && !currentPlaylist.Tracks[currentPlaylist.CurrentTrack].Available {
+		currentPlaylist.CurrentTrack--
+	}
 	m.playlists.SetItem(m.currentPlaylistIndex, currentPlaylist)
 
 	track := &currentPlaylist.Tracks[currentPlaylist.CurrentTrack]
 	if !track.Available {
-		m.Send(tracker.PREV)
+		m.Send(tracker.STOP)
 		return
 	}
 
 	m.playTrack(track)
-	selectedPlaylist := m.playlists.SelectedItem()
-	if currentPlaylist.IsSame(selectedPlaylist) && m.tracklist.Index() == currentPlaylist.CurrentTrack+1 {
+	if shouldFollow {
 		m.tracklist.Select(currentPlaylist.CurrentTrack)
 	}
 }
@@ -110,18 +115,23 @@ func (m *Model) nextTrack() {
 		return
 	}
 
+	selectedPlaylist := m.playlists.SelectedItem()
+	shouldFollow := currentPlaylist.IsSame(selectedPlaylist) && m.tracklist.Index() == currentPlaylist.CurrentTrack
+
 	currentPlaylist.CurrentTrack++
+	for currentPlaylist.CurrentTrack < len(currentPlaylist.Tracks)-1 && !currentPlaylist.Tracks[currentPlaylist.CurrentTrack].Available {
+		currentPlaylist.CurrentTrack++
+	}
 	m.playlists.SetItem(m.currentPlaylistIndex, currentPlaylist)
 
 	track := &currentPlaylist.Tracks[currentPlaylist.CurrentTrack]
 	if !track.Available {
-		m.Send(tracker.NEXT)
+		m.Send(tracker.STOP)
 		return
 	}
 
 	m.playTrack(track)
-	selectedPlaylist := m.playlists.SelectedItem()
-	if currentPlaylist.IsSame(selectedPlaylist) && m.tracklist.Index() == currentPlaylist.CurrentTrack-1 {
+	if shouldFollow {
 		m.tracklist.Select(currentPlaylist.CurrentTrack)
 	}
 }


### PR DESCRIPTION
## Forenote

Before you read all of that, note, that I will be happy to provide different PRs for the issues described below. I didn't create any issues, because it was easier for me to fix them by hand. Some are minor inconsistencies, some, for me, are pretty impactful.

I'm willing to continue my work, and will be glad if maintainers of the project will provide a guide (even a simple one) on how to do that properly, so my PRs don't become a burden for you. I'd like to try to implement some of the things in the roadmap.

There are also couple of features I've been adding for myself, I'll start from them, and after that comes description of what I've fixed (those pesky bugs :smile:).

I've been organizing my work so that any commit is self-contained, focused on one problem, feel free to go commit by commit, there's 10 of them.

### Paragraph about AI usage

Also what I feel you should know - I'm relying on claude code to understand the project. I'm also guiding it when fixing things (when and where to put changes), but the code is heavily reviewed for quality. If it doesn't look good to me, I'm not pushing it. Feel free to correct my code standards, or if you wish that I'd not use that tool in your project. I can code all of that myself, it's way faster for me, allowing this to stay as a hobby, while focusing on main work. Except for the flickering bug maybe, claude + codex were so much help there, the paginator keybindings being the root cause of that, I'd never guess that in that short amount of time, to the point I think I'd left it as it was, because it annoyed me, but not to the point where I'd spend multiple hours fixing it.

## Features

### Volume indicator on the player progress bar

Added a visual volume bar (`Vol ██████████ 100%`) next to the progress bar, using accent/background colors. Shows current volume level at a glance.

### Dynamic volume step acceleration on key hold

Volume keys (`+`/`-`) now accelerate when held down: slow single presses give fine control (20% of configured step), rapid presses ramp up to full step. Uses time delta between key events with three tiers (<80ms, <200ms, default). Also added snap-to-0/snap-to-1 threshold to avoid floating point near-misses.

### Volume keys in player short help

`+`/`-` volume keys are now visible in the short help bar (previously only shown in full help).

### Page-up/page-down keybindings for tracklist

Added `pgup`/`pgdown` as configurable keybindings (`page-up`/`page-down` in config.yaml) for tracklist page navigation. Added to full help view. Replaced hardcoded help height offsets (`-7`/`-5`) with dynamic calculation via `lipgloss.Height()` so the list height adapts to any number of help lines.

## Bug fixes

### 1. readWrapper sending multiple NEXT on track end

**Problem:** When a track finished playing, `readWrapper.Read()` checked `trackBuffer.IsDone()` on every subsequent call from the oto player goroutine. Since `IsDone()` stayed `true`, each call sent another `NEXT` message, causing unintended track skips.

**Fix:** Added a `trackDone` flag that is set once on the first `IsDone()` detection and reset in `NewReader()`. Also gates `ProgressControl` sends behind the same flag to avoid stale progress updates after track end.

### 2. Cursor auto-follow breaking on unavailable track skip

**Problem:** When `nextTrack()`/`prevTrack()` encountered an unavailable track, it called `m.Send(tracker.NEXT)` and returned immediately without moving the cursor. This incremented `CurrentTrack` by 1 but left the cursor behind. When the re-sent `NEXT` was processed and `CurrentTrack` incremented again, the auto-follow condition (`tracklist.Index() == CurrentTrack-1`) permanently failed because the cursor was now 2+ positions behind. The cursor would never follow again until the user manually navigated.

**Fix:** Replaced the `m.Send(tracker.NEXT)` approach with a synchronous loop that skips all consecutive unavailable tracks in one pass. The auto-follow condition was reworked: `shouldFollow` is now computed *before* any state modifications by checking `tracklist.Index() == CurrentTrack` (the current playing position), rather than checking against `CurrentTrack-1` after increment. This is robust regardless of how many tracks are skipped.

### 3. SelectedTrack not synced after cursor auto-follow

**Problem:** `nextTrack()`/`prevTrack()` moved the tracklist cursor via `tracklist.Select()` but never updated `playlist.Item.SelectedTrack`. When the user later navigated playlists (up/down), `displayPlaylist()` used the stale `SelectedTrack` to position the cursor, snapping it back to the old position.

**Fix:** After auto-follow `tracklist.Select()`, also update `SelectedTrack` on the playlist item and save via `SetItem`.

### 4. CurrentTrack/SelectedTrack not adjusted in likeTrack and removeCache

**Problem:** `likeTrack()` (unlike path) and `removeCache()` removed tracks from a playlist via `RemoveTrack()` but never adjusted `CurrentTrack`. If the removed track was above the currently playing track, `CurrentTrack` pointed to the wrong track (off by one). The `RemoveTrack()` method on `playlist.Item` also only handled a boundary case for `SelectedTrack` (past-end clamp) and ignored the general case.

Additionally, both functions used point-wise `tracklist.RemoveItem()` to remove one UI item, but after `RemoveTrack()` shifted the underlying `Tracks` slice via `append([:i], [i+1:]...)`, all tracklist items after the removed index held stale `*api.Track` pointers into old array positions, displaying wrong track data. This was a pre-existing bug masked by the fact that re-entering the playlist (`displayPlaylist()`) recreated all items.

**Fix:**
- `RemoveTrack()` now properly adjusts both `SelectedTrack` (decrement if above removed index, clamp if at end) and `CurrentTrack` (decrement if above, set to `len(Tracks)` if the playing track itself was removed).
- `likeTrack()` and `removeCache()` now call `displayPlaylist()` (same approach as `removeFromPlaylist()`) instead of point-wise `RemoveItem()`, which recreates all tracklist items with fresh pointers from the modified `Tracks` slice.
- After removal, `indicateCurrentTrackPlaying()` is called to restore the play indicator if the playing track was not the one removed.

### 5. Paginator keybindings conflicting with player next/prev (root cause of cursor "jerking")

**Problem:** This was the root cause of the cursor jerking when pressing right/left to switch tracks. The bubbles `list` component used in tracklist contains an internal `Paginator` with default keybindings: `right`=NextPage, `left`=PrevPage. While `tracklist.New()` overrode `list.KeyMap` (setting only CursorUp/CursorDown), the paginator's *own* `KeyMap` was untouched. When a key event arrived, `tracklist.Update()` forwarded all keys to `m.list.Update(msg)`, which in turn called `m.Paginator.Update(msg)` — and the paginator matched `right` as NextPage, changing the page and cursor position *before* the tracker processed the same key and emitted `NEXT`.

By the time `nextTrack()` ran, `tracklist.Index()` was already corrupted by the page change, so `shouldFollow` evaluated to `false` and the cursor didn't follow the track. On the next render, the cursor appeared to "jerk" to a wrong position. With fast double-presses, this created a back-and-forth visual effect between the paginator-shifted position and the actual playing position.

**Fix:** Disabled the paginator's own keybindings via `SetEnabled(false)` after list creation. Page navigation is now handled exclusively through `list.KeyMap.NextPage`/`PrevPage` with explicit `pgup`/`pgdown` bindings (see below), which don't conflict with player controls.

### 6. AddTrack not adjusting indices on prepend

**Problem:** `AddTrack()` prepends a track to the playlist (`append([]Track{new}, existing...)`), shifting all existing indices by 1. But `CurrentTrack` and `SelectedTrack` were not adjusted. When the user added likes from another playlist (e.g. My Wave) and returned to the Likes playlist, the play indicator and cursor pointed to the wrong track (off by N, where N is the number of tracks added).

**Fix:** `AddTrack()` now increments both `SelectedTrack` and `CurrentTrack` (guarded against invalid state) after prepending.