### PR TITLE
Use full track Sequence from RotorNewSession and RotorSessionTracks

### DIFF
--- a/ui/model/mainPage/mainPage.go
+++ b/ui/model/mainPage/mainPage.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/dece2183/yamusic-tui/api"
@@ -350,15 +351,15 @@ func (m *Model) resize(width, height int) {
 }
 
 func (m *Model) initialLoad() {
-	var err error
-
 	m.tracker.HideError()
+
 	if len(config.Current.Token) == 0 {
 		log.Print(log.LVL_ERROR, "missing client token, check the config file at '%s'", config.Path())
 		m.tracker.ShowError("missing token")
 		m.client = nil
 	} else {
-		m.client, err = api.NewClient(config.DirName, config.Current.Token)
+		c, err := api.NewClient(config.DirName, config.Current.Token)
+		m.client = c
 		if err != nil {
 			if _, ok := err.(*url.Error); ok {
 				log.Print(log.LVL_ERROR, "failed to connect to the Yandex server: %s", err)
@@ -370,92 +371,165 @@ func (m *Model) initialLoad() {
 		}
 	}
 
-	for i, station := range m.playlists.Items() {
-		switch station.Kind {
+	myWaveIdx, likesIdx, localIdx := -1, -1, -1
+	for i, st := range m.playlists.Items() {
+		switch st.Kind {
 		case playlist.MYWAVE:
-			if m.client == nil {
-				continue
-			}
-
-			session, err := m.client.RotorNewSession(api.MyWaveId)
-			if err != nil {
-				log.Print(log.LVL_ERROR, "unable to init rotor session: %s", err)
-				m.tracker.ShowError("unable to init rotor session")
-				return
-			}
-
-			station.StationId = session.Id
-			station.SessionId = session.RadioSessionId
-			station.SessionBatch = session.BatchId
-			station.Tracks = []api.Track{session.Sequence[0].Track}
-
-			m.playlists.SetItem(i, station)
+			myWaveIdx = i
 		case playlist.LIKES:
-			if m.client == nil {
-				continue
-			}
-
-			likes, err := m.client.LikedTracks()
-			if err != nil {
-				log.Print(log.LVL_ERROR, "failed to obtain liked tracks for the first time: %s", err)
-				m.tracker.ShowError("liked tracks")
-				continue
-			}
-
-			likedTracksId := make([]string, len(likes))
-			for l, track := range likes {
-				m.likedTracksMap[track.Id] = true
-				likedTracksId[l] = track.Id
-			}
-
-			likedTracks, err := m.client.Tracks(likedTracksId)
-			if err != nil {
-				log.Print(log.LVL_ERROR, "failed to obtain liked tracks full info: %s", err)
-				m.tracker.ShowError("liked tracks info")
-				continue
-			}
-
-			station.Tracks = likedTracks
-			m.playlists.SetItem(i, station)
+			likesIdx = i
 		case playlist.LOCAL:
-			station.Tracks, err = cache.ListTracks()
-			if err != nil {
-				log.Print(log.LVL_ERROR, "failed to list cached tracks: %s", err)
-				m.tracker.ShowError("cache list")
-				continue
-			}
-			for i := range station.Tracks {
-				m.cachedTracksMap[station.Tracks[i].Id] = true
-			}
-			m.playlists.SetItem(i, station)
-		default:
+			localIdx = i
 		}
 	}
 
-	if m.client != nil {
-		playlists, err := m.client.ListPlaylists()
-		if err == nil {
-			for _, pl := range playlists {
-				playlistTracks, err := m.client.PlaylistTracks(pl.Kind, pl.Owner.Uid, false)
-				if err != nil {
-					log.Print(log.LVL_ERROR, "failed to obtain playlist [%s] tracks: %s", pl.Title, err)
-					m.tracker.ShowError("playlist tracks")
-					continue
-				}
+	var (
+		wg sync.WaitGroup
 
-				m.playlists.InsertItem(-1, &playlist.Item{
-					Name:     pl.Title,
-					Kind:     pl.Kind,
-					Revision: pl.Revision,
-					Active:   true,
-					Subitem:  true,
-					Tracks:   playlistTracks,
-				})
+		myWaveSession api.StationTracks
+		myWaveErr     error
+
+		likedTracksFull []api.Track
+		likedTracksIds  []string
+		likedErr        error
+
+		localTracks []api.Track
+		localErr    error
+
+		userPlaylists      []api.Playlist
+		userPlaylistsErr   error
+		userPlaylistTracks [][]api.Track
+	)
+
+	if m.client != nil && myWaveIdx >= 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			session, err := m.client.RotorNewSession(api.MyWaveId)
+			myWaveSession = session
+			myWaveErr = err
+		}()
+	}
+
+	if m.client != nil && likesIdx >= 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			likes, err := m.client.LikedTracks()
+			if err != nil {
+				likedErr = err
+				return
 			}
-		} else {
-			log.Print(log.LVL_ERROR, "failed to obtain user playlists: %s", err)
-			m.tracker.ShowError("playlists")
+			ids := make([]string, len(likes))
+			for i, tr := range likes {
+				ids[i] = tr.Id
+			}
+			likedTracksIds = ids
+			full, err := m.client.Tracks(ids)
+			likedTracksFull = full
+			likedErr = err
+		}()
+	}
+
+	if localIdx >= 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tracks, err := cache.ListTracks()
+			localTracks = tracks
+			localErr = err
+		}()
+	}
+
+	if m.client != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pls, err := m.client.ListPlaylists()
+			if err != nil {
+				userPlaylistsErr = err
+				return
+			}
+			userPlaylists = pls
+			userPlaylistTracks = make([][]api.Track, len(pls))
+
+			var innerWg sync.WaitGroup
+			for i, pl := range pls {
+				innerWg.Add(1)
+				go func(i int, pl api.Playlist) {
+					defer innerWg.Done()
+					tracks, terr := m.client.PlaylistTracks(pl.Kind, pl.Owner.Uid, false)
+					if terr != nil {
+						log.Print(log.LVL_ERROR, "failed to obtain playlist [%s] tracks: %s", pl.Title, terr)
+						return
+					}
+					userPlaylistTracks[i] = tracks
+				}(i, pl)
+			}
+			innerWg.Wait()
+		}()
+	}
+
+	wg.Wait()
+
+	if myWaveIdx >= 0 && myWaveErr == nil && m.client != nil {
+		st := m.playlists.Items()[myWaveIdx]
+		st.StationId = myWaveSession.Id
+		st.SessionId = myWaveSession.RadioSessionId
+		st.SessionBatch = myWaveSession.BatchId
+		if len(myWaveSession.Sequence) > 0 {
+			st.Tracks = []api.Track{myWaveSession.Sequence[0].Track}
 		}
+		m.playlists.SetItem(myWaveIdx, st)
+	} else if myWaveErr != nil {
+		log.Print(log.LVL_ERROR, "unable to init rotor session: %s", myWaveErr)
+		m.tracker.ShowError("unable to init rotor session")
+		return
+	}
+
+	if likesIdx >= 0 && likedErr == nil && m.client != nil {
+		for _, id := range likedTracksIds {
+			m.likedTracksMap[id] = true
+		}
+		st := m.playlists.Items()[likesIdx]
+		st.Tracks = likedTracksFull
+		m.playlists.SetItem(likesIdx, st)
+	} else if likedErr != nil {
+		log.Print(log.LVL_ERROR, "failed to obtain liked tracks: %s", likedErr)
+		m.tracker.ShowError("liked tracks")
+	}
+
+	if localIdx >= 0 && localErr == nil {
+		st := m.playlists.Items()[localIdx]
+		st.Tracks = localTracks
+		for _, tr := range localTracks {
+			m.cachedTracksMap[tr.Id] = true
+		}
+		m.playlists.SetItem(localIdx, st)
+	} else if localErr != nil {
+		log.Print(log.LVL_ERROR, "failed to list cached tracks: %s", localErr)
+		m.tracker.ShowError("cache list")
+	}
+
+	if m.client != nil && userPlaylistsErr == nil {
+		for i, pl := range userPlaylists {
+			tracks := userPlaylistTracks[i]
+			if tracks == nil {
+				m.tracker.ShowError("playlist tracks")
+				continue
+			}
+			m.playlists.InsertItem(-1, &playlist.Item{
+				Name:     pl.Title,
+				Kind:     pl.Kind,
+				Revision: pl.Revision,
+				Active:   true,
+				Subitem:  true,
+				Tracks:   tracks,
+			})
+		}
+	} else if userPlaylistsErr != nil {
+		log.Print(log.LVL_ERROR, "failed to obtain user playlists: %s", userPlaylistsErr)
+		m.tracker.ShowError("playlists")
 	}
 
 	m.currentPlaylistIndex = -1

--- a/ui/model/mainPage/mainPage.go
+++ b/ui/model/mainPage/mainPage.go
@@ -478,7 +478,10 @@ func (m *Model) initialLoad() {
 		st.SessionId = myWaveSession.RadioSessionId
 		st.SessionBatch = myWaveSession.BatchId
 		if len(myWaveSession.Sequence) > 0 {
-			st.Tracks = []api.Track{myWaveSession.Sequence[0].Track}
+			st.Tracks = make([]api.Track, 0, len(myWaveSession.Sequence))
+			for _, item := range myWaveSession.Sequence {
+				st.Tracks = append(st.Tracks, item.Track)
+			}
 		}
 		m.playlists.SetItem(myWaveIdx, st)
 	} else if myWaveErr != nil {

--- a/ui/model/mainPage/playControl.go
+++ b/ui/model/mainPage/playControl.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	_ "image/jpeg"
 	_ "image/png"
@@ -167,87 +168,108 @@ func (m *Model) playTrack(track *api.Track) {
 	m.tracker.Stop()
 
 	var (
-		coverFile  *os.File
-		coverStat  os.FileInfo
+		wg sync.WaitGroup
+
 		coverType  string
 		coverBytes []byte
-		err        error
+
+		lyrics []api.LyricPair
+
+		trackReader    io.ReadCloser
+		trackSize      int64
+		trackFromCache bool
+		downloadErr    error
 	)
 
-	coverPath := m.coverFilePath(track)
-	coverFile, err = os.OpenFile(coverPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
-	if err != nil {
-		log.Print(log.LVL_WARNIGN, "unable to open cover file [%s]: %s", coverPath, err)
-		goto skipcover
-	}
-
-	defer coverFile.Close()
-
-	coverStat, err = coverFile.Stat()
-	if err != nil || coverStat.Size() == 0 {
-		coverType, err = api.DownloadTrackCover(coverFile, track, 200)
-		if err != nil {
-			log.Print(log.LVL_WARNIGN, "unable to download track [%s] cover: %s", track.Id, err)
-			goto skipcover
-		}
-		coverFile.Sync()
-		stat, _ := coverFile.Stat()
-		coverBytes = make([]byte, stat.Size())
-		coverFile.Seek(0, io.SeekStart)
-		coverFile.Read(coverBytes)
-	}
-
-skipcover:
-	var trackFromCache bool
-	var trackBuffer *stream.BufferedStream
-	var trackReader io.ReadCloser
-	var trackSize int64
-	var lyrics []api.LyricPair
-	if track.LyricsInfo.HasAvailableSyncLyrics {
-		lyrics, err = m.client.TrackLyricsRequest(track.Id)
-		if err != nil {
-			log.Print(log.LVL_WARNIGN, "failed to obtain track [%s] lyrics: %s", track.Id, err)
-			m.tracker.ShowError("track lyrics")
-		}
-	}
-	trackReader, trackSize, err = cache.Read(track.Id)
-	if err == nil {
-		trackFromCache = true
-	} else {
-		var trackInfos []api.TrackDownloadInfo
-		var bestTrackInfo api.TrackDownloadInfo
-
-		for i := 0; i < _TRACK_DOWNLOAD_TRIES; i++ {
-			trackInfos, err = m.client.TrackDownloadInfo(track.Id)
-			if err != nil {
-				log.Print(log.LVL_ERROR, "failed to obtain track [%s] info: %s", track.Id, err)
-				continue
-			}
-
-			var bestBitrate int
-			for _, t := range trackInfos {
-				if t.BbitrateInKbps > bestBitrate {
-					bestBitrate = t.BbitrateInKbps
-					bestTrackInfo = t
-				}
-			}
-
-			trackReader, trackSize, err = m.client.DownloadTrack(bestTrackInfo)
-			if err != nil {
-				log.Print(log.LVL_ERROR, "failed to download track [%s]: %s", track.Id, err)
-				continue
-			}
-
-			break
-		}
-
-		if err != nil {
-			m.tracker.ShowError("track download")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		coverPath := m.coverFilePath(track)
+		coverFile, ferr := os.OpenFile(coverPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
+		if ferr != nil {
+			log.Print(log.LVL_WARNIGN, "unable to open cover file [%s]: %s", coverPath, ferr)
 			return
 		}
+		defer coverFile.Close()
+		stat, serr := coverFile.Stat()
+		if serr != nil || stat.Size() == 0 {
+			cType, derr := api.DownloadTrackCover(coverFile, track, 200)
+			if derr != nil {
+				log.Print(log.LVL_WARNIGN, "unable to download track [%s] cover: %s", track.Id, derr)
+				return
+			}
+			coverType = cType
+			coverFile.Sync()
+			s, _ := coverFile.Stat()
+			buf := make([]byte, s.Size())
+			coverFile.Seek(0, io.SeekStart)
+			coverFile.Read(buf)
+			coverBytes = buf
+		}
+	}()
+
+	if track.LyricsInfo.HasAvailableSyncLyrics {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lyr, lerr := m.client.TrackLyricsRequest(track.Id)
+			if lerr != nil {
+				log.Print(log.LVL_WARNIGN, "failed to obtain track [%s] lyrics: %s", track.Id, lerr)
+				m.tracker.ShowError("track lyrics")
+				return
+			}
+			lyrics = lyr
+		}()
 	}
 
-	trackBuffer = stream.NewBufferedStream(trackReader, trackSize)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tr, ts, cerr := cache.Read(track.Id)
+		if cerr == nil {
+			trackReader = tr
+			trackSize = ts
+			trackFromCache = true
+			return
+		}
+		var lastErr error
+		for i := 0; i < _TRACK_DOWNLOAD_TRIES; i++ {
+			trackInfos, ierr := m.client.TrackDownloadInfo(track.Id)
+			if ierr != nil {
+				log.Print(log.LVL_ERROR, "failed to obtain track [%s] info: %s", track.Id, ierr)
+				lastErr = ierr
+				continue
+			}
+			var bestBitrate int
+			var bestTrackInfo api.TrackDownloadInfo
+			for _, ti := range trackInfos {
+				if ti.BbitrateInKbps > bestBitrate {
+					bestBitrate = ti.BbitrateInKbps
+					bestTrackInfo = ti
+				}
+			}
+			tr2, ts2, derr := m.client.DownloadTrack(bestTrackInfo)
+			if derr != nil {
+				log.Print(log.LVL_ERROR, "failed to download track [%s]: %s", track.Id, derr)
+				lastErr = derr
+				continue
+			}
+			trackReader = tr2
+			trackSize = ts2
+			lastErr = nil
+			break
+		}
+		downloadErr = lastErr
+	}()
+
+	wg.Wait()
+
+	if downloadErr != nil && trackReader == nil {
+		m.tracker.ShowError("track download")
+		return
+	}
+
+	trackBuffer := stream.NewBufferedStream(trackReader, trackSize)
 	metadataFile, err := os.OpenFile(m.metadataFilePath(), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
 	if err == nil {
 		tag := id3v2.NewEmptyTag()

--- a/ui/model/mainPage/playControl.go
+++ b/ui/model/mainPage/playControl.go
@@ -56,18 +56,41 @@ func (m *Model) rotateTracks(currentPlaylist *playlist.Item) {
 	}
 
 	currentPlaylist.SessionBatch = suggestedTracks.BatchId
-	currentPlaylist.Tracks = append(currentPlaylist.Tracks, suggestedTracks.Sequence[0].Track)
+
+	existing := make(map[string]bool, len(currentPlaylist.Tracks))
+	for _, t := range currentPlaylist.Tracks {
+		existing[t.Id] = true
+	}
+	addedStart := len(currentPlaylist.Tracks)
+	for _, item := range suggestedTracks.Sequence {
+		if existing[item.Track.Id] {
+			continue
+		}
+		existing[item.Track.Id] = true
+		currentPlaylist.Tracks = append(currentPlaylist.Tracks, item.Track)
+	}
+
+	if len(currentPlaylist.Tracks) == addedStart {
+		return
+	}
 
 	if m.playlists.SelectedItem().IsSame(currentPlaylist) {
 		tackItems := m.tracklist.Items()
-		lastTrack := tackItems[len(tackItems)-1]
-		lastTrack.IsSuggestion = false
-		m.tracklist.SetItem(len(tackItems)-1, lastTrack)
-		m.tracklist.InsertItem(-1, tracklist.Item{
-			Track:        &currentPlaylist.Tracks[len(currentPlaylist.Tracks)-1],
-			Artists:      helpers.ArtistList(suggestedTracks.Sequence[0].Track.Artists),
-			IsSuggestion: true,
-		})
+		if len(tackItems) > 0 {
+			lastTrack := tackItems[len(tackItems)-1]
+			lastTrack.IsSuggestion = false
+			m.tracklist.SetItem(len(tackItems)-1, lastTrack)
+		}
+		for i := addedStart; i < len(currentPlaylist.Tracks); i++ {
+			item := tracklist.Item{
+				Track:   &currentPlaylist.Tracks[i],
+				Artists: helpers.ArtistList(currentPlaylist.Tracks[i].Artists),
+			}
+			if i == len(currentPlaylist.Tracks)-1 {
+				item.IsSuggestion = true
+			}
+			m.tracklist.InsertItem(-1, item)
+		}
 	}
 }
 


### PR DESCRIPTION
# Use full track Sequence from RotorNewSession and RotorSessionTracks

## Summary

`RotorNewSession` and `RotorSessionTracks` return a `Sequence` of multiple tracks per response (typically 5–10). The current code uses only `Sequence[0]` and discards the rest, so the user sees one track at a time in `My Wave` until they finish playing it.

This PR uses the entire returned `Sequence`, with deduplication by track ID against what's already in the playlist.

## What changed

### `ui/model/mainPage/mainPage.go`
In the `initialLoad` apply phase, the My Wave station's tracks are now populated from every entry in `myWaveSession.Sequence`, not just `Sequence[0]`.

### `ui/model/mainPage/playControl.go` — `rotateTracks`
When the user reaches the end of the My Wave queue and `rotateTracks` fetches the next batch via `RotorSessionTracks`, the code now appends every new track from the response (deduplicating by `Track.Id`), updates the corresponding tracklist items, and keeps the very last track marked as `IsSuggestion`. Previously only `Sequence[0]` was appended.

## Why

The server already returns a batch — there's no API cost to using it. The result is that the user starts with a populated wave and the queue stays ahead of the playhead by ~5–10 tracks, which is what every other Yandex Music client does.

Dedup is needed because `RotorSessionTracks` is called with the current `currentPlaylist.Tracks` as context, and the response can include tracks already known to the client.

## Test plan

- [x] `go build` and `go vet` clean
- [x] Open My Wave on a fresh account-cache — sidebar item shows multiple tracks immediately
- [x] Play through tracks until the last one starts — `rotateTracks` appends the next batch (multiple new tracks visible) instead of one at a time
- [x] No duplicate tracks appear in the list
