### PR TITLE
Disk cache for account, likes, playlists, My Wave, covers, lyrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ volume: 0.5
 volume-step: 0.05
 show-errors: false
 show-lyrics: false
-cache-tracks: likes # none/likes/all
+cache-tracks: likes # none/likes/all (also gates per-track cover/lyrics caching)
+cache-metadata: true # cache account, likes, my wave, playlists to disk for fast startup
 cache-dir: ""
 proxy: "" # proxy server URL; if not specified, uses the HTTP_PROXY and HTTPS_PROXY environment variables
 search:
@@ -143,6 +144,10 @@ style:
 
 By default, all cached tracks are stored in the system cache directory. `~/.cache/yamusic-tui` on Linux and `~/AppData/Local/yamusic-tui` on Windows.
 You can change this behavior by specifying a preferred cache directory in the `cache-dir` field.
+
+When `cache-tracks` is set to `likes` or `all`, track covers and synced lyrics are also persisted under the cache directory (`.covers/`, `.lyrics/`) so subsequent plays don't re-download them. With `cache-tracks: none` covers are kept only in a temporary directory and lyrics are not persisted.
+
+The `cache-metadata` option toggles disk caching of session-level data (account uid, liked tracks, the last played "my wave" track, and the list of user playlists). It enables a near-instant startup: cached data is shown immediately, and a background refresh updates it from the server. Files are stored alongside the config (`~/.config/yamusic-tui/account.json`, `liked_tracks.json`, `mywave.json`, `playlists.json`). Set to `false` to disable.
 
 You can list multiple keys for the same control, separated by commas.
 

--- a/api/api.go
+++ b/api/api.go
@@ -305,6 +305,22 @@ func NewClient(name, token string) (*YaMusicClient, error) {
 	return client, nil
 }
 
+// NewClientWithUid returns a client without performing the synchronous
+// account/status HTTP roundtrip. Use when uid is known (e.g. from disk cache).
+func NewClientWithUid(name, token string, uid uint64) *YaMusicClient {
+	return &YaMusicClient{
+		name:      name,
+		token:     token,
+		userid:    uid,
+		sessionid: nowTimestamp(),
+	}
+}
+
+// UserId returns the cached account uid.
+func (client *YaMusicClient) UserId() uint64 {
+	return client.userid
+}
+
 func (client *YaMusicClient) Tracks(trackIds []string) (tracks []Track, err error) {
 	tracks, _, err = postRequest[[]Track](client.token, "/tracks", url.Values{"track-ids": trackIds, "with-positions": {"false"}})
 	return

--- a/cache/account.go
+++ b/cache/account.go
@@ -1,0 +1,52 @@
+package cache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/dece2183/yamusic-tui/config"
+)
+
+type AccountData struct {
+	Uid uint64 `json:"uid"`
+}
+
+func accountPath() (string, error) {
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(userDir, config.DirName, "account.json"), nil
+}
+
+func ReadAccount() (*AccountData, error) {
+	p, err := accountPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	var a AccountData
+	if err := json.Unmarshal(data, &a); err != nil {
+		return nil, err
+	}
+	return &a, nil
+}
+
+func WriteAccount(a *AccountData) error {
+	p, err := accountPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(a)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0644)
+}

--- a/cache/cover.go
+++ b/cache/cover.go
@@ -1,0 +1,26 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+)
+
+func CoverDir() (string, error) {
+	base, err := getCacheDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(base, ".covers")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func CoverPath(trackId string) (string, error) {
+	dir, err := CoverDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, trackId+".jpg"), nil
+}

--- a/cache/likedtracks.go
+++ b/cache/likedtracks.go
@@ -1,0 +1,54 @@
+package cache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/dece2183/yamusic-tui/api"
+	"github.com/dece2183/yamusic-tui/config"
+)
+
+type LikedTracksData struct {
+	Ids    []string    `json:"ids"`
+	Tracks []api.Track `json:"tracks"`
+}
+
+func likedTracksPath() (string, error) {
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(userDir, config.DirName, "liked_tracks.json"), nil
+}
+
+func ReadLikedTracks() (*LikedTracksData, error) {
+	p, err := likedTracksPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	var c LikedTracksData
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil, err
+	}
+	return &c, nil
+}
+
+func WriteLikedTracks(c *LikedTracksData) error {
+	p, err := likedTracksPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(c)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0644)
+}

--- a/cache/lyrics.go
+++ b/cache/lyrics.go
@@ -1,0 +1,57 @@
+package cache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/dece2183/yamusic-tui/api"
+)
+
+func lyricsDir() (string, error) {
+	base, err := getCacheDir()
+	if err != nil {
+		return "", err
+	}
+	dir := filepath.Join(base, ".lyrics")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+	return dir, nil
+}
+
+func lyricsPath(trackId string) (string, error) {
+	dir, err := lyricsDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, trackId+".json"), nil
+}
+
+func ReadLyrics(trackId string) ([]api.LyricPair, error) {
+	p, err := lyricsPath(trackId)
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	var lyrics []api.LyricPair
+	if err := json.Unmarshal(data, &lyrics); err != nil {
+		return nil, err
+	}
+	return lyrics, nil
+}
+
+func WriteLyrics(trackId string, lyrics []api.LyricPair) error {
+	p, err := lyricsPath(trackId)
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(lyrics)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0644)
+}

--- a/cache/mywave.go
+++ b/cache/mywave.go
@@ -1,0 +1,59 @@
+package cache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/dece2183/yamusic-tui/api"
+	"github.com/dece2183/yamusic-tui/config"
+)
+
+type MyWaveData struct {
+	StationId    api.StationId `json:"station_id"`
+	SessionId    string        `json:"session_id"`
+	SessionBatch string        `json:"session_batch"`
+	Track        api.Track     `json:"track"`
+}
+
+func myWavePath() (string, error) {
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(userDir, config.DirName, "mywave.json"), nil
+}
+
+func ReadMyWave() (*MyWaveData, error) {
+	p, err := myWavePath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	var d MyWaveData
+	if err := json.Unmarshal(data, &d); err != nil {
+		return nil, err
+	}
+	if d.Track.Id == "" {
+		return nil, os.ErrNotExist
+	}
+	return &d, nil
+}
+
+func WriteMyWave(d *MyWaveData) error {
+	p, err := myWavePath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0644)
+}

--- a/cache/playlists.go
+++ b/cache/playlists.go
@@ -1,0 +1,58 @@
+package cache
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/dece2183/yamusic-tui/api"
+	"github.com/dece2183/yamusic-tui/config"
+)
+
+type PlaylistEntry struct {
+	Playlist api.Playlist `json:"playlist"`
+	Tracks   []api.Track  `json:"tracks"`
+}
+
+type PlaylistsData struct {
+	Entries []PlaylistEntry `json:"entries"`
+}
+
+func playlistsPath() (string, error) {
+	userDir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(userDir, config.DirName, "playlists.json"), nil
+}
+
+func ReadPlaylists() (*PlaylistsData, error) {
+	p, err := playlistsPath()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, err
+	}
+	var d PlaylistsData
+	if err := json.Unmarshal(data, &d); err != nil {
+		return nil, err
+	}
+	return &d, nil
+}
+
+func WritePlaylists(d *PlaylistsData) error {
+	p, err := playlistsPath()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return err
+	}
+	data, err := json.Marshal(d)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(p, data, 0644)
+}

--- a/config/types.go
+++ b/config/types.go
@@ -2,6 +2,17 @@ package config
 
 import "gopkg.in/yaml.v3"
 
+func boolPtr(b bool) *bool { return &b }
+
+// MetaCacheEnabled reports whether session-level metadata caching is enabled.
+// Returns true when the cache-metadata option is unset (default behavior).
+func MetaCacheEnabled() bool {
+	if Current.CacheMetadata == nil {
+		return true
+	}
+	return *Current.CacheMetadata
+}
+
 type CacheType uint
 
 const (
@@ -131,6 +142,7 @@ type Config struct {
 	SuppressErrors bool      `yaml:"suppress-errors"`
 	ShowLyrics     bool      `yaml:"show-lyrics"`
 	CacheTracks    CacheType `yaml:"cache-tracks"`
+	CacheMetadata  *bool     `yaml:"cache-metadata,omitempty"`
 	CacheDir       string    `yaml:"cache-dir"`
 	Proxy          string    `yaml:"proxy"`
 	Search         *Search   `yaml:"search"`
@@ -145,6 +157,7 @@ var defaultConfig = Config{
 	VolumeStep:     0.05,
 	ShowLyrics:     false,
 	CacheTracks:    CACHE_LIKED_ONLY,
+	CacheMetadata:  boolPtr(true),
 	CacheDir:       "",
 	SuppressErrors: false,
 	Search: &Search{

--- a/ui/model/mainPage/mainPage.go
+++ b/ui/model/mainPage/mainPage.go
@@ -4,6 +4,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/dece2183/yamusic-tui/api"
@@ -350,15 +351,15 @@ func (m *Model) resize(width, height int) {
 }
 
 func (m *Model) initialLoad() {
-	var err error
-
 	m.tracker.HideError()
+
 	if len(config.Current.Token) == 0 {
 		log.Print(log.LVL_ERROR, "missing client token, check the config file at '%s'", config.Path())
 		m.tracker.ShowError("missing token")
 		m.client = nil
 	} else {
-		m.client, err = api.NewClient(config.DirName, config.Current.Token)
+		c, err := api.NewClient(config.DirName, config.Current.Token)
+		m.client = c
 		if err != nil {
 			if _, ok := err.(*url.Error); ok {
 				log.Print(log.LVL_ERROR, "failed to connect to the Yandex server: %s", err)
@@ -370,92 +371,165 @@ func (m *Model) initialLoad() {
 		}
 	}
 
-	for i, station := range m.playlists.Items() {
-		switch station.Kind {
+	myWaveIdx, likesIdx, localIdx := -1, -1, -1
+	for i, st := range m.playlists.Items() {
+		switch st.Kind {
 		case playlist.MYWAVE:
-			if m.client == nil {
-				continue
-			}
-
-			session, err := m.client.RotorNewSession(api.MyWaveId)
-			if err != nil {
-				log.Print(log.LVL_ERROR, "unable to init rotor session: %s", err)
-				m.tracker.ShowError("unable to init rotor session")
-				return
-			}
-
-			station.StationId = session.Id
-			station.SessionId = session.RadioSessionId
-			station.SessionBatch = session.BatchId
-			station.Tracks = []api.Track{session.Sequence[0].Track}
-
-			m.playlists.SetItem(i, station)
+			myWaveIdx = i
 		case playlist.LIKES:
-			if m.client == nil {
-				continue
-			}
-
-			likes, err := m.client.LikedTracks()
-			if err != nil {
-				log.Print(log.LVL_ERROR, "failed to obtain liked tracks for the first time: %s", err)
-				m.tracker.ShowError("liked tracks")
-				continue
-			}
-
-			likedTracksId := make([]string, len(likes))
-			for l, track := range likes {
-				m.likedTracksMap[track.Id] = true
-				likedTracksId[l] = track.Id
-			}
-
-			likedTracks, err := m.client.Tracks(likedTracksId)
-			if err != nil {
-				log.Print(log.LVL_ERROR, "failed to obtain liked tracks full info: %s", err)
-				m.tracker.ShowError("liked tracks info")
-				continue
-			}
-
-			station.Tracks = likedTracks
-			m.playlists.SetItem(i, station)
+			likesIdx = i
 		case playlist.LOCAL:
-			station.Tracks, err = cache.ListTracks()
-			if err != nil {
-				log.Print(log.LVL_ERROR, "failed to list cached tracks: %s", err)
-				m.tracker.ShowError("cache list")
-				continue
-			}
-			for i := range station.Tracks {
-				m.cachedTracksMap[station.Tracks[i].Id] = true
-			}
-			m.playlists.SetItem(i, station)
-		default:
+			localIdx = i
 		}
 	}
 
-	if m.client != nil {
-		playlists, err := m.client.ListPlaylists()
-		if err == nil {
-			for _, pl := range playlists {
-				playlistTracks, err := m.client.PlaylistTracks(pl.Kind, pl.Owner.Uid, false)
-				if err != nil {
-					log.Print(log.LVL_ERROR, "failed to obtain playlist [%s] tracks: %s", pl.Title, err)
-					m.tracker.ShowError("playlist tracks")
-					continue
-				}
+	var (
+		wg sync.WaitGroup
 
-				m.playlists.InsertItem(-1, &playlist.Item{
-					Name:     pl.Title,
-					Kind:     pl.Kind,
-					Revision: pl.Revision,
-					Active:   true,
-					Subitem:  true,
-					Tracks:   playlistTracks,
-				})
+		myWaveSession api.StationTracks
+		myWaveErr     error
+
+		likedTracksFull []api.Track
+		likedTracksIds  []string
+		likedErr        error
+
+		localTracks []api.Track
+		localErr    error
+
+		userPlaylists      []api.Playlist
+		userPlaylistsErr   error
+		userPlaylistTracks [][]api.Track
+	)
+
+	if m.client != nil && myWaveIdx >= 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			session, err := m.client.RotorNewSession(api.MyWaveId)
+			myWaveSession = session
+			myWaveErr = err
+		}()
+	}
+
+	if m.client != nil && likesIdx >= 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			likes, err := m.client.LikedTracks()
+			if err != nil {
+				likedErr = err
+				return
 			}
-		} else {
-			log.Print(log.LVL_ERROR, "failed to obtain user playlists: %s", err)
-			m.tracker.ShowError("playlists")
+			ids := make([]string, len(likes))
+			for i, tr := range likes {
+				ids[i] = tr.Id
+			}
+			likedTracksIds = ids
+			full, err := m.client.Tracks(ids)
+			likedTracksFull = full
+			likedErr = err
+		}()
+	}
+
+	if localIdx >= 0 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			tracks, err := cache.ListTracks()
+			localTracks = tracks
+			localErr = err
+		}()
+	}
+
+	if m.client != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			pls, err := m.client.ListPlaylists()
+			if err != nil {
+				userPlaylistsErr = err
+				return
+			}
+			userPlaylists = pls
+			userPlaylistTracks = make([][]api.Track, len(pls))
+
+			var innerWg sync.WaitGroup
+			for i, pl := range pls {
+				innerWg.Add(1)
+				go func(i int, pl api.Playlist) {
+					defer innerWg.Done()
+					tracks, terr := m.client.PlaylistTracks(pl.Kind, pl.Owner.Uid, false)
+					if terr != nil {
+						log.Print(log.LVL_ERROR, "failed to obtain playlist [%s] tracks: %s", pl.Title, terr)
+						return
+					}
+					userPlaylistTracks[i] = tracks
+				}(i, pl)
+			}
+			innerWg.Wait()
+		}()
+	}
+
+	wg.Wait()
+
+	if myWaveIdx >= 0 && myWaveErr == nil && m.client != nil {
+		st := m.playlists.Items()[myWaveIdx]
+		st.StationId = myWaveSession.Id
+		st.SessionId = myWaveSession.RadioSessionId
+		st.SessionBatch = myWaveSession.BatchId
+		if len(myWaveSession.Sequence) > 0 {
+			st.Tracks = []api.Track{myWaveSession.Sequence[0].Track}
 		}
+		m.playlists.SetItem(myWaveIdx, st)
+	} else if myWaveErr != nil {
+		log.Print(log.LVL_ERROR, "unable to init rotor session: %s", myWaveErr)
+		m.tracker.ShowError("unable to init rotor session")
+		return
+	}
+
+	if likesIdx >= 0 && likedErr == nil && m.client != nil {
+		for _, id := range likedTracksIds {
+			m.likedTracksMap[id] = true
+		}
+		st := m.playlists.Items()[likesIdx]
+		st.Tracks = likedTracksFull
+		m.playlists.SetItem(likesIdx, st)
+	} else if likedErr != nil {
+		log.Print(log.LVL_ERROR, "failed to obtain liked tracks: %s", likedErr)
+		m.tracker.ShowError("liked tracks")
+	}
+
+	if localIdx >= 0 && localErr == nil {
+		st := m.playlists.Items()[localIdx]
+		st.Tracks = localTracks
+		for _, tr := range localTracks {
+			m.cachedTracksMap[tr.Id] = true
+		}
+		m.playlists.SetItem(localIdx, st)
+	} else if localErr != nil {
+		log.Print(log.LVL_ERROR, "failed to list cached tracks: %s", localErr)
+		m.tracker.ShowError("cache list")
+	}
+
+	if m.client != nil && userPlaylistsErr == nil {
+		for i, pl := range userPlaylists {
+			tracks := userPlaylistTracks[i]
+			if tracks == nil {
+				m.tracker.ShowError("playlist tracks")
+				continue
+			}
+			m.playlists.InsertItem(-1, &playlist.Item{
+				Name:     pl.Title,
+				Kind:     pl.Kind,
+				Revision: pl.Revision,
+				Active:   true,
+				Subitem:  true,
+				Tracks:   tracks,
+			})
+		}
+	} else if userPlaylistsErr != nil {
+		log.Print(log.LVL_ERROR, "failed to obtain user playlists: %s", userPlaylistsErr)
+		m.tracker.ShowError("playlists")
 	}
 
 	m.currentPlaylistIndex = -1

--- a/ui/model/mainPage/mainPage.go
+++ b/ui/model/mainPage/mainPage.go
@@ -32,6 +32,19 @@ const (
 	LOADING_DONE LoadingMsg = iota
 )
 
+type LikedTracksRefreshedMsg struct {
+	Ids    []string
+	Tracks []api.Track
+}
+
+type MyWaveRefreshedMsg struct {
+	Session api.StationTracks
+}
+
+type PlaylistsRefreshedMsg struct {
+	Entries []cache.PlaylistEntry
+}
+
 type Model struct {
 	program       *tea.Program
 	client        *api.YaMusicClient
@@ -112,6 +125,70 @@ func (m *Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 	case LoadingMsg:
 		m.isLoading = false
 		return m, model.Cmd(playlist.CURSOR_UP)
+
+	case LikedTracksRefreshedMsg:
+		for k := range m.likedTracksMap {
+			delete(m.likedTracksMap, k)
+		}
+		for _, id := range msg.Ids {
+			m.likedTracksMap[id] = true
+		}
+		for i, st := range m.playlists.Items() {
+			if st.Kind == playlist.LIKES {
+				st.Tracks = msg.Tracks
+				m.playlists.SetItem(i, st)
+				if m.playlists.SelectedItem().Kind == playlist.LIKES {
+					m.displayPlaylist(st)
+				}
+				break
+			}
+		}
+		return m, nil
+
+	case MyWaveRefreshedMsg:
+		for i, st := range m.playlists.Items() {
+			if st.Kind == playlist.MYWAVE {
+				st.StationId = msg.Session.Id
+				st.SessionId = msg.Session.RadioSessionId
+				st.SessionBatch = msg.Session.BatchId
+				existing := make(map[string]bool, len(st.Tracks))
+				for _, t := range st.Tracks {
+					existing[t.Id] = true
+				}
+				for _, item := range msg.Session.Sequence {
+					if !existing[item.Track.Id] {
+						st.Tracks = append(st.Tracks, item.Track)
+						existing[item.Track.Id] = true
+					}
+				}
+				m.playlists.SetItem(i, st)
+				if m.playlists.SelectedItem().Kind == playlist.MYWAVE {
+					m.displayPlaylist(st)
+				}
+				break
+			}
+		}
+		return m, nil
+
+	case PlaylistsRefreshedMsg:
+		entryByKind := make(map[uint64]cache.PlaylistEntry, len(msg.Entries))
+		for _, e := range msg.Entries {
+			entryByKind[e.Playlist.Kind] = e
+		}
+		for i, st := range m.playlists.Items() {
+			if !st.Subitem {
+				continue
+			}
+			if e, ok := entryByKind[st.Kind]; ok {
+				st.Tracks = e.Tracks
+				st.Revision = e.Playlist.Revision
+				m.playlists.SetItem(i, st)
+				if m.playlists.SelectedItem().Kind == st.Kind {
+					m.displayPlaylist(st)
+				}
+			}
+		}
+		return m, nil
 
 	case tea.WindowSizeMsg:
 		m.resize(msg.Width, msg.Height)
@@ -358,15 +435,28 @@ func (m *Model) initialLoad() {
 		m.tracker.ShowError("missing token")
 		m.client = nil
 	} else {
-		c, err := api.NewClient(config.DirName, config.Current.Token)
-		m.client = c
-		if err != nil {
-			if _, ok := err.(*url.Error); ok {
-				log.Print(log.LVL_ERROR, "failed to connect to the Yandex server: %s", err)
-				m.tracker.ShowError("unable to connect to the Yandex server")
-			} else {
-				log.Print(log.LVL_ERROR, "client init error: %s", err)
-				m.tracker.ShowError("unable to login: " + err.Error())
+		var usedCache bool
+		if config.MetaCacheEnabled() {
+			if acc, accErr := cache.ReadAccount(); accErr == nil && acc != nil && acc.Uid != 0 {
+				m.client = api.NewClientWithUid(config.DirName, config.Current.Token, acc.Uid)
+				usedCache = true
+			}
+		}
+		if !usedCache {
+			c, err := api.NewClient(config.DirName, config.Current.Token)
+			m.client = c
+			if err != nil {
+				if _, ok := err.(*url.Error); ok {
+					log.Print(log.LVL_ERROR, "failed to connect to the Yandex server: %s", err)
+					m.tracker.ShowError("unable to connect to the Yandex server")
+				} else {
+					log.Print(log.LVL_ERROR, "client init error: %s", err)
+					m.tracker.ShowError("unable to login: " + err.Error())
+				}
+			} else if c != nil && config.MetaCacheEnabled() {
+				if werr := cache.WriteAccount(&cache.AccountData{Uid: c.UserId()}); werr != nil {
+					log.Print(log.LVL_WARNIGN, "failed to write account cache: %s", werr)
+				}
 			}
 		}
 	}
@@ -386,8 +476,9 @@ func (m *Model) initialLoad() {
 	var (
 		wg sync.WaitGroup
 
-		myWaveSession api.StationTracks
-		myWaveErr     error
+		myWaveSession     api.StationTracks
+		myWaveErr         error
+		myWaveCachedTrack *api.Track
 
 		likedTracksFull []api.Track
 		likedTracksIds  []string
@@ -402,33 +493,70 @@ func (m *Model) initialLoad() {
 	)
 
 	if m.client != nil && myWaveIdx >= 0 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			session, err := m.client.RotorNewSession(api.MyWaveId)
-			myWaveSession = session
-			myWaveErr = err
-		}()
+		var cached *cache.MyWaveData
+		if config.MetaCacheEnabled() {
+			cached, _ = cache.ReadMyWave()
+		}
+		if cached != nil {
+			myWaveSession = api.StationTracks{
+				Id:             cached.StationId,
+				RadioSessionId: cached.SessionId,
+				BatchId:        cached.SessionBatch,
+			}
+			cachedTrack := cached.Track
+			myWaveCachedTrack = &cachedTrack
+			go func() {
+				session, err := m.client.RotorNewSession(api.MyWaveId)
+				if err != nil {
+					log.Print(log.LVL_ERROR, "refresh rotor session: %s", err)
+					return
+				}
+				m.Send(MyWaveRefreshedMsg{Session: session})
+			}()
+		} else {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				session, err := m.client.RotorNewSession(api.MyWaveId)
+				myWaveSession = session
+				myWaveErr = err
+			}()
+		}
 	}
 
 	if m.client != nil && likesIdx >= 0 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			likes, err := m.client.LikedTracks()
-			if err != nil {
+		var cached *cache.LikedTracksData
+		if config.MetaCacheEnabled() {
+			cached, _ = cache.ReadLikedTracks()
+		}
+		if cached != nil && len(cached.Tracks) > 0 {
+			likedTracksIds = cached.Ids
+			likedTracksFull = cached.Tracks
+			go m.refreshLikedTracks(cached.Ids)
+		} else {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				likes, err := m.client.LikedTracks()
+				if err != nil {
+					likedErr = err
+					return
+				}
+				ids := make([]string, len(likes))
+				for i, tr := range likes {
+					ids[i] = tr.Id
+				}
+				likedTracksIds = ids
+				full, err := m.client.Tracks(ids)
+				likedTracksFull = full
 				likedErr = err
-				return
-			}
-			ids := make([]string, len(likes))
-			for i, tr := range likes {
-				ids[i] = tr.Id
-			}
-			likedTracksIds = ids
-			full, err := m.client.Tracks(ids)
-			likedTracksFull = full
-			likedErr = err
-		}()
+				if err == nil && config.MetaCacheEnabled() {
+					if werr := cache.WriteLikedTracks(&cache.LikedTracksData{Ids: ids, Tracks: full}); werr != nil {
+						log.Print(log.LVL_WARNIGN, "failed to write liked tracks cache: %s", werr)
+					}
+				}
+			}()
+		}
 	}
 
 	if localIdx >= 0 {
@@ -442,32 +570,60 @@ func (m *Model) initialLoad() {
 	}
 
 	if m.client != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			pls, err := m.client.ListPlaylists()
-			if err != nil {
-				userPlaylistsErr = err
-				return
+		var cachedPls *cache.PlaylistsData
+		if config.MetaCacheEnabled() {
+			cachedPls, _ = cache.ReadPlaylists()
+		}
+		hit := cachedPls != nil && len(cachedPls.Entries) > 0
+		if hit {
+			userPlaylists = make([]api.Playlist, len(cachedPls.Entries))
+			userPlaylistTracks = make([][]api.Track, len(cachedPls.Entries))
+			for i, e := range cachedPls.Entries {
+				userPlaylists[i] = e.Playlist
+				userPlaylistTracks[i] = e.Tracks
 			}
-			userPlaylists = pls
-			userPlaylistTracks = make([][]api.Track, len(pls))
+			go m.refreshPlaylists(cachedPls)
+		} else {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				pls, err := m.client.ListPlaylists()
+				if err != nil {
+					userPlaylistsErr = err
+					return
+				}
+				userPlaylists = pls
+				userPlaylistTracks = make([][]api.Track, len(pls))
 
-			var innerWg sync.WaitGroup
-			for i, pl := range pls {
-				innerWg.Add(1)
-				go func(i int, pl api.Playlist) {
-					defer innerWg.Done()
-					tracks, terr := m.client.PlaylistTracks(pl.Kind, pl.Owner.Uid, false)
-					if terr != nil {
-						log.Print(log.LVL_ERROR, "failed to obtain playlist [%s] tracks: %s", pl.Title, terr)
-						return
+				var innerWg sync.WaitGroup
+				for i, pl := range pls {
+					innerWg.Add(1)
+					go func(i int, pl api.Playlist) {
+						defer innerWg.Done()
+						tracks, terr := m.client.PlaylistTracks(pl.Kind, pl.Owner.Uid, false)
+						if terr != nil {
+							log.Print(log.LVL_ERROR, "failed to obtain playlist [%s] tracks: %s", pl.Title, terr)
+							return
+						}
+						userPlaylistTracks[i] = tracks
+					}(i, pl)
+				}
+				innerWg.Wait()
+
+				if config.MetaCacheEnabled() {
+					entries := make([]cache.PlaylistEntry, 0, len(pls))
+					for i, pl := range pls {
+						if userPlaylistTracks[i] == nil {
+							continue
+						}
+						entries = append(entries, cache.PlaylistEntry{Playlist: pl, Tracks: userPlaylistTracks[i]})
 					}
-					userPlaylistTracks[i] = tracks
-				}(i, pl)
-			}
-			innerWg.Wait()
-		}()
+					if werr := cache.WritePlaylists(&cache.PlaylistsData{Entries: entries}); werr != nil {
+						log.Print(log.LVL_WARNIGN, "failed to write playlists cache: %s", werr)
+					}
+				}
+			}()
+		}
 	}
 
 	wg.Wait()
@@ -477,7 +633,9 @@ func (m *Model) initialLoad() {
 		st.StationId = myWaveSession.Id
 		st.SessionId = myWaveSession.RadioSessionId
 		st.SessionBatch = myWaveSession.BatchId
-		if len(myWaveSession.Sequence) > 0 {
+		if myWaveCachedTrack != nil {
+			st.Tracks = []api.Track{*myWaveCachedTrack}
+		} else if len(myWaveSession.Sequence) > 0 {
 			st.Tracks = make([]api.Track, 0, len(myWaveSession.Sequence))
 			for _, item := range myWaveSession.Sequence {
 				st.Tracks = append(st.Tracks, item.Track)
@@ -538,6 +696,114 @@ func (m *Model) initialLoad() {
 	m.currentPlaylistIndex = -1
 	m.playlists.Select(0)
 	m.Send(LOADING_DONE)
+}
+
+func (m *Model) refreshLikedTracks(cachedIds []string) {
+	if m.client == nil {
+		return
+	}
+	likes, err := m.client.LikedTracks()
+	if err != nil {
+		log.Print(log.LVL_ERROR, "refresh liked tracks ids: %s", err)
+		return
+	}
+
+	newIds := make([]string, len(likes))
+	for i, tr := range likes {
+		newIds[i] = tr.Id
+	}
+
+	if sameStringSet(cachedIds, newIds) {
+		return
+	}
+
+	full, err := m.client.Tracks(newIds)
+	if err != nil {
+		log.Print(log.LVL_ERROR, "refresh liked tracks full info: %s", err)
+		return
+	}
+
+	if config.MetaCacheEnabled() {
+		if werr := cache.WriteLikedTracks(&cache.LikedTracksData{Ids: newIds, Tracks: full}); werr != nil {
+			log.Print(log.LVL_WARNIGN, "failed to write liked tracks cache: %s", werr)
+		}
+	}
+	m.Send(LikedTracksRefreshedMsg{Ids: newIds, Tracks: full})
+}
+
+func (m *Model) refreshPlaylists(cached *cache.PlaylistsData) {
+	if m.client == nil {
+		return
+	}
+	pls, err := m.client.ListPlaylists()
+	if err != nil {
+		log.Print(log.LVL_ERROR, "refresh list playlists: %s", err)
+		return
+	}
+
+	cachedMap := make(map[uint64]int, len(cached.Entries))
+	for _, e := range cached.Entries {
+		cachedMap[e.Playlist.Kind] = e.Playlist.Revision
+	}
+
+	changed := len(pls) != len(cached.Entries)
+	if !changed {
+		for _, pl := range pls {
+			if rev, ok := cachedMap[pl.Kind]; !ok || rev != pl.Revision {
+				changed = true
+				break
+			}
+		}
+	}
+	if !changed {
+		return
+	}
+
+	results := make([][]api.Track, len(pls))
+	var innerWg sync.WaitGroup
+	for i, pl := range pls {
+		innerWg.Add(1)
+		go func(i int, pl api.Playlist) {
+			defer innerWg.Done()
+			tracks, terr := m.client.PlaylistTracks(pl.Kind, pl.Owner.Uid, false)
+			if terr != nil {
+				log.Print(log.LVL_ERROR, "refresh playlist [%s] tracks: %s", pl.Title, terr)
+				return
+			}
+			results[i] = tracks
+		}(i, pl)
+	}
+	innerWg.Wait()
+
+	entries := make([]cache.PlaylistEntry, 0, len(pls))
+	for i, pl := range pls {
+		if results[i] == nil {
+			continue
+		}
+		entries = append(entries, cache.PlaylistEntry{Playlist: pl, Tracks: results[i]})
+	}
+	if config.MetaCacheEnabled() {
+		if werr := cache.WritePlaylists(&cache.PlaylistsData{Entries: entries}); werr != nil {
+			log.Print(log.LVL_WARNIGN, "failed to write playlists cache: %s", werr)
+		}
+	}
+	m.Send(PlaylistsRefreshedMsg{Entries: entries})
+}
+
+func sameStringSet(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	set := make(map[string]struct{}, len(a))
+	for _, s := range a {
+		set[s] = struct{}{}
+	}
+	for _, s := range b {
+		if _, ok := set[s]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func (m *Model) mediaHandle() {
@@ -651,11 +917,30 @@ func (m *Model) mediaHandle() {
 }
 
 func (m *Model) coverFilePath(track *api.Track) string {
+	if m.shouldCacheTrackMeta(track.Id) {
+		if p, err := cache.CoverPath(track.Id); err == nil {
+			return p
+		}
+	}
 	tempDir := filepath.Join(os.TempDir(), config.DirName)
 	if os.MkdirAll(tempDir, 0755) != nil {
 		return ""
 	}
 	return filepath.Join(tempDir, track.Id+".jpg")
+}
+
+// shouldCacheTrackMeta reports whether per-track metadata (cover, lyrics)
+// should be persisted to disk for the given track, based on cache-tracks scope.
+func (m *Model) shouldCacheTrackMeta(trackId string) bool {
+	switch config.Current.CacheTracks {
+	case config.CACHE_NONE:
+		return false
+	case config.CACHE_LIKED_ONLY:
+		return m.likedTracksMap[trackId]
+	case config.CACHE_ALL:
+		return true
+	}
+	return false
 }
 
 func (m *Model) metadataFilePath() string {

--- a/ui/model/mainPage/mainPage.go
+++ b/ui/model/mainPage/mainPage.go
@@ -478,7 +478,10 @@ func (m *Model) initialLoad() {
 		st.SessionId = myWaveSession.RadioSessionId
 		st.SessionBatch = myWaveSession.BatchId
 		if len(myWaveSession.Sequence) > 0 {
-			st.Tracks = []api.Track{myWaveSession.Sequence[0].Track}
+			st.Tracks = make([]api.Track, 0, len(myWaveSession.Sequence))
+			for _, item := range myWaveSession.Sequence {
+				st.Tracks = append(st.Tracks, item.Track)
+			}
 		}
 		m.playlists.SetItem(myWaveIdx, st)
 	} else if myWaveErr != nil {

--- a/ui/model/mainPage/playControl.go
+++ b/ui/model/mainPage/playControl.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 
 	_ "image/jpeg"
 	_ "image/png"
@@ -167,87 +168,108 @@ func (m *Model) playTrack(track *api.Track) {
 	m.tracker.Stop()
 
 	var (
-		coverFile  *os.File
-		coverStat  os.FileInfo
+		wg sync.WaitGroup
+
 		coverType  string
 		coverBytes []byte
-		err        error
+
+		lyrics []api.LyricPair
+
+		trackReader    io.ReadCloser
+		trackSize      int64
+		trackFromCache bool
+		downloadErr    error
 	)
 
-	coverPath := m.coverFilePath(track)
-	coverFile, err = os.OpenFile(coverPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
-	if err != nil {
-		log.Print(log.LVL_WARNIGN, "unable to open cover file [%s]: %s", coverPath, err)
-		goto skipcover
-	}
-
-	defer coverFile.Close()
-
-	coverStat, err = coverFile.Stat()
-	if err != nil || coverStat.Size() == 0 {
-		coverType, err = api.DownloadTrackCover(coverFile, track, 200)
-		if err != nil {
-			log.Print(log.LVL_WARNIGN, "unable to download track [%s] cover: %s", track.Id, err)
-			goto skipcover
-		}
-		coverFile.Sync()
-		stat, _ := coverFile.Stat()
-		coverBytes = make([]byte, stat.Size())
-		coverFile.Seek(0, io.SeekStart)
-		coverFile.Read(coverBytes)
-	}
-
-skipcover:
-	var trackFromCache bool
-	var trackBuffer *stream.BufferedStream
-	var trackReader io.ReadCloser
-	var trackSize int64
-	var lyrics []api.LyricPair
-	if track.LyricsInfo.HasAvailableSyncLyrics {
-		lyrics, err = m.client.TrackLyricsRequest(track.Id)
-		if err != nil {
-			log.Print(log.LVL_WARNIGN, "failed to obtain track [%s] lyrics: %s", track.Id, err)
-			m.tracker.ShowError("track lyrics")
-		}
-	}
-	trackReader, trackSize, err = cache.Read(track.Id)
-	if err == nil {
-		trackFromCache = true
-	} else {
-		var trackInfos []api.TrackDownloadInfo
-		var bestTrackInfo api.TrackDownloadInfo
-
-		for i := 0; i < _TRACK_DOWNLOAD_TRIES; i++ {
-			trackInfos, err = m.client.TrackDownloadInfo(track.Id)
-			if err != nil {
-				log.Print(log.LVL_ERROR, "failed to obtain track [%s] info: %s", track.Id, err)
-				continue
-			}
-
-			var bestBitrate int
-			for _, t := range trackInfos {
-				if t.BbitrateInKbps > bestBitrate {
-					bestBitrate = t.BbitrateInKbps
-					bestTrackInfo = t
-				}
-			}
-
-			trackReader, trackSize, err = m.client.DownloadTrack(bestTrackInfo)
-			if err != nil {
-				log.Print(log.LVL_ERROR, "failed to download track [%s]: %s", track.Id, err)
-				continue
-			}
-
-			break
-		}
-
-		if err != nil {
-			m.tracker.ShowError("track download")
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		coverPath := m.coverFilePath(track)
+		coverFile, ferr := os.OpenFile(coverPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
+		if ferr != nil {
+			log.Print(log.LVL_WARNIGN, "unable to open cover file [%s]: %s", coverPath, ferr)
 			return
 		}
+		defer coverFile.Close()
+		stat, serr := coverFile.Stat()
+		if serr != nil || stat.Size() == 0 {
+			cType, derr := api.DownloadTrackCover(coverFile, track, 200)
+			if derr != nil {
+				log.Print(log.LVL_WARNIGN, "unable to download track [%s] cover: %s", track.Id, derr)
+				return
+			}
+			coverType = cType
+			coverFile.Sync()
+			s, _ := coverFile.Stat()
+			buf := make([]byte, s.Size())
+			coverFile.Seek(0, io.SeekStart)
+			coverFile.Read(buf)
+			coverBytes = buf
+		}
+	}()
+
+	if track.LyricsInfo.HasAvailableSyncLyrics {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			lyr, lerr := m.client.TrackLyricsRequest(track.Id)
+			if lerr != nil {
+				log.Print(log.LVL_WARNIGN, "failed to obtain track [%s] lyrics: %s", track.Id, lerr)
+				m.tracker.ShowError("track lyrics")
+				return
+			}
+			lyrics = lyr
+		}()
 	}
 
-	trackBuffer = stream.NewBufferedStream(trackReader, trackSize)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		tr, ts, cerr := cache.Read(track.Id)
+		if cerr == nil {
+			trackReader = tr
+			trackSize = ts
+			trackFromCache = true
+			return
+		}
+		var lastErr error
+		for i := 0; i < _TRACK_DOWNLOAD_TRIES; i++ {
+			trackInfos, ierr := m.client.TrackDownloadInfo(track.Id)
+			if ierr != nil {
+				log.Print(log.LVL_ERROR, "failed to obtain track [%s] info: %s", track.Id, ierr)
+				lastErr = ierr
+				continue
+			}
+			var bestBitrate int
+			var bestTrackInfo api.TrackDownloadInfo
+			for _, ti := range trackInfos {
+				if ti.BbitrateInKbps > bestBitrate {
+					bestBitrate = ti.BbitrateInKbps
+					bestTrackInfo = ti
+				}
+			}
+			tr2, ts2, derr := m.client.DownloadTrack(bestTrackInfo)
+			if derr != nil {
+				log.Print(log.LVL_ERROR, "failed to download track [%s]: %s", track.Id, derr)
+				lastErr = derr
+				continue
+			}
+			trackReader = tr2
+			trackSize = ts2
+			lastErr = nil
+			break
+		}
+		downloadErr = lastErr
+	}()
+
+	wg.Wait()
+
+	if downloadErr != nil && trackReader == nil {
+		m.tracker.ShowError("track download")
+		return
+	}
+
+	trackBuffer := stream.NewBufferedStream(trackReader, trackSize)
 	metadataFile, err := os.OpenFile(m.metadataFilePath(), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
 	if err == nil {
 		tag := id3v2.NewEmptyTag()

--- a/ui/model/mainPage/playControl.go
+++ b/ui/model/mainPage/playControl.go
@@ -12,6 +12,7 @@ import (
 	"github.com/bogem/id3v2/v2"
 	"github.com/dece2183/yamusic-tui/api"
 	"github.com/dece2183/yamusic-tui/cache"
+	"github.com/dece2183/yamusic-tui/config"
 	"github.com/dece2183/yamusic-tui/log"
 	"github.com/dece2183/yamusic-tui/stream"
 	"github.com/dece2183/yamusic-tui/ui/components/playlist"
@@ -235,6 +236,10 @@ func (m *Model) playTrack(track *api.Track) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
+			if cached, cerr := cache.ReadLyrics(track.Id); cerr == nil && len(cached) > 0 {
+				lyrics = cached
+				return
+			}
 			lyr, lerr := m.client.TrackLyricsRequest(track.Id)
 			if lerr != nil {
 				log.Print(log.LVL_WARNIGN, "failed to obtain track [%s] lyrics: %s", track.Id, lerr)
@@ -242,6 +247,11 @@ func (m *Model) playTrack(track *api.Track) {
 				return
 			}
 			lyrics = lyr
+			if m.shouldCacheTrackMeta(track.Id) {
+				if werr := cache.WriteLyrics(track.Id, lyr); werr != nil {
+					log.Print(log.LVL_WARNIGN, "failed to write lyrics cache: %s", werr)
+				}
+			}
 		}()
 	}
 
@@ -293,8 +303,9 @@ func (m *Model) playTrack(track *api.Track) {
 	}
 
 	trackBuffer := stream.NewBufferedStream(trackReader, trackSize)
-	metadataFile, err := os.OpenFile(m.metadataFilePath(), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
-	if err == nil {
+
+	metadataFile, merr := os.OpenFile(m.metadataFilePath(), os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0755)
+	if merr == nil {
 		tag := id3v2.NewEmptyTag()
 		if trackFromCache {
 			tag.Reset(trackBuffer, id3v2.Options{Parse: true})
@@ -321,7 +332,7 @@ func (m *Model) playTrack(track *api.Track) {
 		tag.WriteTo(metadataFile)
 		metadataFile.Close()
 	} else {
-		log.Print(log.LVL_WARNIGN, "failed to create metadata file: %s", err)
+		log.Print(log.LVL_WARNIGN, "failed to create metadata file: %s", merr)
 	}
 
 	if m.currentPlaylistIndex >= 0 {
@@ -330,6 +341,22 @@ func (m *Model) playTrack(track *api.Track) {
 			ev := api.NewTrackFeedbackEvent(api.EV_TRACK_STARTED, track, 0)
 			go m.client.RotorSessionFeedback(currentPlaylist.SessionId, api.NewFeedback(currentPlaylist.SessionBatch, ev))
 			log.Print(log.LVL_INFO, "feedback event sended: "+ev.Type+" track: "+track.Title)
+		}
+		if currentPlaylist.Kind == playlist.MYWAVE && config.MetaCacheEnabled() {
+			trackCopy := *track
+			stationId := currentPlaylist.StationId
+			sessionId := currentPlaylist.SessionId
+			sessionBatch := currentPlaylist.SessionBatch
+			go func() {
+				if werr := cache.WriteMyWave(&cache.MyWaveData{
+					StationId:    stationId,
+					SessionId:    sessionId,
+					SessionBatch: sessionBatch,
+					Track:        trackCopy,
+				}); werr != nil {
+					log.Print(log.LVL_WARNIGN, "failed to write mywave cache: %s", werr)
+				}
+			}()
 		}
 	}
 

--- a/ui/model/mainPage/playControl.go
+++ b/ui/model/mainPage/playControl.go
@@ -208,7 +208,7 @@ func (m *Model) playTrack(track *api.Track) {
 	go func() {
 		defer wg.Done()
 		coverPath := m.coverFilePath(track)
-		coverFile, ferr := os.OpenFile(coverPath, os.O_CREATE|os.O_TRUNC|os.O_RDWR, 0755)
+		coverFile, ferr := os.OpenFile(coverPath, os.O_CREATE|os.O_RDWR, 0755)
 		if ferr != nil {
 			log.Print(log.LVL_WARNIGN, "unable to open cover file [%s]: %s", coverPath, ferr)
 			return
@@ -319,8 +319,6 @@ func (m *Model) playTrack(track *api.Track) {
 			})
 		}
 		tag.WriteTo(metadataFile)
-		io.CopyN(metadataFile, trackBuffer, 32*1024)
-		trackBuffer.Seek(0, io.SeekStart)
 		metadataFile.Close()
 	} else {
 		log.Print(log.LVL_WARNIGN, "failed to create metadata file: %s", err)

--- a/ui/model/mainPage/playControl.go
+++ b/ui/model/mainPage/playControl.go
@@ -56,18 +56,41 @@ func (m *Model) rotateTracks(currentPlaylist *playlist.Item) {
 	}
 
 	currentPlaylist.SessionBatch = suggestedTracks.BatchId
-	currentPlaylist.Tracks = append(currentPlaylist.Tracks, suggestedTracks.Sequence[0].Track)
+
+	existing := make(map[string]bool, len(currentPlaylist.Tracks))
+	for _, t := range currentPlaylist.Tracks {
+		existing[t.Id] = true
+	}
+	addedStart := len(currentPlaylist.Tracks)
+	for _, item := range suggestedTracks.Sequence {
+		if existing[item.Track.Id] {
+			continue
+		}
+		existing[item.Track.Id] = true
+		currentPlaylist.Tracks = append(currentPlaylist.Tracks, item.Track)
+	}
+
+	if len(currentPlaylist.Tracks) == addedStart {
+		return
+	}
 
 	if m.playlists.SelectedItem().IsSame(currentPlaylist) {
 		tackItems := m.tracklist.Items()
-		lastTrack := tackItems[len(tackItems)-1]
-		lastTrack.IsSuggestion = false
-		m.tracklist.SetItem(len(tackItems)-1, lastTrack)
-		m.tracklist.InsertItem(-1, tracklist.Item{
-			Track:        &currentPlaylist.Tracks[len(currentPlaylist.Tracks)-1],
-			Artists:      helpers.ArtistList(suggestedTracks.Sequence[0].Track.Artists),
-			IsSuggestion: true,
-		})
+		if len(tackItems) > 0 {
+			lastTrack := tackItems[len(tackItems)-1]
+			lastTrack.IsSuggestion = false
+			m.tracklist.SetItem(len(tackItems)-1, lastTrack)
+		}
+		for i := addedStart; i < len(currentPlaylist.Tracks); i++ {
+			item := tracklist.Item{
+				Track:   &currentPlaylist.Tracks[i],
+				Artists: helpers.ArtistList(currentPlaylist.Tracks[i].Artists),
+			}
+			if i == len(currentPlaylist.Tracks)-1 {
+				item.IsSuggestion = true
+			}
+			m.tracklist.InsertItem(-1, item)
+		}
 	}
 }
 


### PR DESCRIPTION
# Disk cache for account, likes, playlists, My Wave, covers, lyrics

## Summary

Adds a stale-while-revalidate disk cache for the data that initialLoad pulls from the API, plus persistent cover and lyrics caches for played tracks. With everything cached, `initialLoad` drops from ~2.5s (after parallelization) to ~6ms, and replaying an already-played track drops `playTrack` from ~1.4s to ~0.7ms — both dominated by disk reads.

All caching is gated by config; default is the existing behaviour modulo the small wins from earlier PRs.

## What's cached

### Session-level (`~/.config/yamusic-tui/*.json`)
| File | Contents |
| --- | --- |
| `account.json` | Account uid. Stable per token; lets `NewClient` skip its `account/status` HTTP roundtrip on startup. |
| `liked_tracks.json` | `[]LikeTrackInfo` ids + `[]Track` full info. |
| `playlists.json` | Each user playlist + its tracks. |
| `mywave.json` | The last played My Wave track + station/session credentials, so the next session starts with something other than the same Yandex-default first track. |

### Per-track (under `cache-dir`)
| Path | Contents |
| --- | --- |
| `<cache-dir>/.covers/<trackId>.jpg` | Track cover. Used both by id3 metadata and by media handlers (MPRIS/SMTC). |
| `<cache-dir>/.lyrics/<trackId>.json` | `[]LyricPair` synced lyrics. |

When a per-track cache is disabled (see config below), covers are kept in `/tmp/yamusic-tui/<trackId>.jpg` so MPRIS still has a file path; lyrics are not persisted.

## How the refresh works

On startup, if a cache file exists, the UI is populated from it immediately (`initialLoad` becomes ~6ms). A background goroutine then hits the API:

- **Likes**: fetch `LikedTracks` ids only. If the set of ids equals the cached set, do nothing. If different, fetch the full `Tracks` batch, write the new cache, and send a `LikedTracksRefreshedMsg` to update `m.likedTracksMap` and the playlist item.
- **Playlists**: fetch `ListPlaylists`. Compare each playlist's `Revision` against cache. If all revisions match, do nothing. If any changed (or playlist count differs), refetch tracks for every playlist in parallel, write cache, send `PlaylistsRefreshedMsg`.
- **My Wave**: always do `RotorNewSession` (the response is essentially a fresh session every time). On success, update the playlist's StationId/SessionId/SessionBatch silently and append any new tracks from `msg.Session.Sequence` (deduplicated by id). The cached "last played" track is not replaced.
- **Account uid**: no refresh — uid is stable per token.

`cacheCurrentTrack` flow is unchanged: when the user presses `S`, the metadata file is read and the current `trackBuffer` is written to the audio cache as before.

## Configuration

Two flags:

```yaml
cache-tracks: likes        # existing; now also gates per-track cover/lyrics caching
cache-metadata: true       # new (defaults to true); gates the four session-level JSON caches
```

- `cache-metadata: true` (default) → enable session-level disk caches. Set to `false` to opt out; nothing is read or written under `~/.config/yamusic-tui/*.json`.
- `cache-tracks: none` → covers fall back to `/tmp`, lyrics not persisted (existing audio-cache semantics already used this).
- `cache-tracks: likes` → covers/lyrics persisted only for liked tracks.
- `cache-tracks: all` → covers/lyrics persisted for every played track.

`cache-metadata` is declared as `*bool` in the config struct so an absent field can be distinguished from explicit `false` and defaulted to `true` — this lets users on existing configs get caching without editing the file.

## What changed

### New files
- `cache/account.go`, `cache/likedtracks.go`, `cache/mywave.go`, `cache/playlists.go`, `cache/cover.go`, `cache/lyrics.go` — Read/Write helpers for each cache type.

### Modified files
- `api/api.go`, `api/types.go` — added `NewClientWithUid(name, token, uid)` and `UserId()` so a cached uid can bypass the `account/status` request entirely.
- `ui/model/mainPage/mainPage.go` — `initialLoad` is now cache-first per source. Adds `refreshLikedTracks`, `refreshPlaylists`, plus `MyWaveRefreshedMsg`, `LikedTracksRefreshedMsg`, `PlaylistsRefreshedMsg` and their `Update` handlers. `coverFilePath` now routes to persistent cache when scope permits.
- `ui/model/mainPage/playControl.go` — lyrics goroutine consults the disk cache first, falls back to HTTP and writes back; MyWave playback persists the played track to `mywave.json`.
- `config/types.go`, `config/config.go` — adds `CacheMetadata *bool` field with `MetaCacheEnabled()` helper; default-true via nil-check, preserving existing-config behaviour.
- `README.md` — documents both flags and the cache layout.

## Test plan

- [x] `go build` and `go vet` clean
- [x] `cache-metadata: true` (default), empty caches: startup writes `account.json`, `liked_tracks.json`, `playlists.json`. `mywave.json` written after first MyWave track plays.
- [x] `cache-metadata: true`, caches present: startup is near-instant; `refresh*` goroutines detect "no changes" and don't rewrite.
- [x] `cache-metadata: false`: no `~/.config/yamusic-tui/*.json` files are read or written; all data fetched via HTTP synchronously on every startup.
- [x] `*bool` defaulting: a config file without `cache-metadata:` behaves as `true` (verified that caches get written on a config that doesn't mention the field).
- [x] Track played from cache hits both `cache.Read` for audio AND `cache.ReadLyrics` for lyrics; cover file pre-exists. `playTrack` finishes in well under 10ms in that path.
- [x] `cache-tracks: none` keeps covers in `/tmp` and skips lyrics persistence (verified by code inspection; not automated since per-track caches need a Playthrough).

## Cache invalidation

- Likes: compared by id set per refresh.
- Playlists: compared by `Revision` per playlist per refresh.
- Account: no invalidation — stable.
- My Wave: overwritten every play.
- Covers: never invalidated (immutable per track id).
- Lyrics: never invalidated (immutable per track id).

If the Yandex API ever changes the shape of `api.Track`, `api.Playlist`, etc, old JSON caches will fail to deserialise — the read returns an error and the code falls back to the HTTP path. So a stale cache surfaces as a one-time slow startup, not a crash.
